### PR TITLE
Wavlength calibration from raw data

### DIFF
--- a/examples/python/reduc_thar.py
+++ b/examples/python/reduc_thar.py
@@ -1,0 +1,112 @@
+from pyird.utils import irdstream
+from pyird.spec.wavcal import wavcal_thar
+from pyird.image.bias import bias_subtract_image
+from pyird.image.hotpix import identify_hotpix
+from pyird.spec.rsdmat import multiorder_to_rsd
+from pyird.image.oned_extract import flatten
+from pyird.plot.detector import corrected_detector
+from pyird.image.pattern_model import median_XY_profile
+from pyird.image.trace_function import trace_legendre
+from pyird.image.mask import trace
+from pyird.io.iraf_trace import read_trace_file
+from pyird.plot.order import plot_refthar
+from pyird.io.read_linelist import read_linelist
+import astropy.io.fits as pyf
+from scipy.signal import medfilt
+import pathlib
+import numpy as np
+import pandas as pd
+import pkg_resources
+
+import argparse
+import matplotlib.pyplot as plt
+
+def imcorrect(date,im):
+    """read pattern removal.
+    """
+    # image for calibration
+    calim = np.copy(im)
+    # read pattern removal
+    pathC = 'path/to/apwhite_mask'  #(pkg_resources.resource_filename('pyird', 'data/samples/aprefC'))
+    #pathC = pathlib.Path('/Volumes/IRD/IRD/observation_BD/data/hband/%d/database/apwhite_mask'%(date))
+    y0, interp_function, xmin, xmax, coeff = read_trace_file(pathC) #([pathC, path_c])
+    mask = trace(im, trace_legendre, y0, xmin, xmax, coeff)
+    calim[mask] = np.nan
+    calim[hotpix_mask] = np.nan
+    model_im = median_XY_profile(calim,show=plot)
+    corrected_im = im-model_im
+    #corrected_detector(im, model_im, corrected_im)
+    return corrected_im
+
+def im_to_rsd(date,corrected_im,mode='mmf2'):
+    """One Dimensionalization.
+    """
+    # trace
+    if mode=='mmf2':
+        pathA = 'path/to/apwhite_mmf2_r'  #(pkg_resources.resource_filename('pyird', 'data/samples/aprefB'))
+        #pathA = pathlib.Path('/Volumes/IRD/IRD/observation_BD/data/hband/%d/database/apwhite_mmf2_r'%(date))
+    elif mode=='mmf1':
+        pathA = 'path/to/apwhite_mmf1_r'
+        #pathA = pathlib.Path('/Volumes/IRD/IRD/observation_BD/data/hband/%d/database/apwhite_mmf1_r'%(date))
+    y0, interp_function, xmin, xmax, coeff = read_trace_file(pathA)
+    # flatten
+    rawspec, pixcoord = flatten(
+        corrected_im, trace_legendre, y0, xmin, xmax, coeff)
+    # rsd
+    rsd = multiorder_to_rsd(rawspec, pixcoord)
+    return rsd
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='copy of REARCH.py')
+    parser.add_argument('-d', type=int, nargs=1, default=[20210321], help='date')
+    parser.add_argument('--dark', type=int, nargs=1,default=[41955], help='dark frame')
+    parser.add_argument('--thar', type=int, nargs=2,default=[14893, 14942], help='thar_star frame; start, stop')
+    parser.add_argument('--step', type=int, nargs=1,default=[1],help='thar_star step of frame number')
+    parser.add_argument('--mode', nargs=1,default=['mmf2'], help='mmf1 (lfc fiber) or mmf2 (star fiber)')
+    parser.add_argument('--plot',default=False, help='plot')
+
+    args = parser.parse_args()
+    date = args.d[0]
+    fdark = args.dark
+    fthar = list(range(args.thar[0],args.thar[1],args.step[0]))
+    mode = arge.mode[0]
+    plot = args.plot
+
+    # hotpixel mask
+    datadir = pathlib.Path('/Users/yuikasagi/IRD/PhDwork/pyird/data/dark/')
+    anadir = pathlib.Path('/Users/yuikasagi/IRD/PhDwork/pyird/data/dark/')
+    dark = irdstream.Stream2D('targets', datadir, anadir)
+    dark.fitsid = fdark
+    for data in dark.rawpath:
+        im = pyf.open(str(data))[0].data
+    im_subbias = bias_subtract_image(im)
+    hotpix_mask, obj = identify_hotpix(im_subbias)
+
+    # thar images
+    datadir = pathlib.Path('/Volumes/IRD/IRD/observation_BD/data/hband/%d/raw/'%(date))
+    anadir = pathlib.Path('/Users/yuikasagi/IRD/PhDwork/pyird/data/%d/'%(date))
+    if args.step[0]==1:
+        rawtag='IRDAD000'
+    elif args.step[0]==2:
+        rawtag='IRDA000'
+    thars1 = irdstream.Stream2D('thars1', datadir, anadir, rawtag=rawtag)
+    thars1.fitsid = fthar  # THARSTAR
+
+    # Load an images
+    corrected_im_all = []
+    for datapath in thars1.rawpath:
+        im = pyf.open(str(datapath))[0].data
+        corrected_im = imcorrect(date,im)
+        corrected_im_all.append(corrected_im)
+
+    # median combine of thar spectra
+    thar1_comb = np.nanmedian(corrected_im_all,axis=0) #np.nansum(corrected_im_all,axis=0)#
+    rsd = im_to_rsd(date,thar1_comb,mode=mode)
+
+    dat = rsd.T
+
+    # wavlength calibration
+    wavsol2, data2 = wavcal_thar(dat,maxiter=30,stdlim=0.001)
+    print('features = ', len(data2.ravel()[data2.ravel()!=0]))
+    plot_refthar(wavsol2, data2, 21)
+    np.savetxt('./wavsol2.txt',wavsol2)

--- a/src/pyird/spec/wavcal.py
+++ b/src/pyird/spec/wavcal.py
@@ -2,8 +2,16 @@ import numpy as np
 from scipy.optimize import leastsq
 import matplotlib.pyplot as plt
 
+import pandas as pd
+from pyird.plot.order import plot_refthar
+from pyird.io.read_linelist import read_linelist
+from astropy.io import fits
+from scipy.signal import medfilt
 
-def pdat_to_wavmat(pdat, npix=2048):
+import pkg_resources
+
+
+def pdat_to_wavmat(pdat, j, l, npix=2048):
     """conversion channel-wavelength data to wavelength matrix.
 
     Args:
@@ -106,31 +114,35 @@ def sigmaclip(data, wavsol, N=3):
             n += 1
     return residuals, drop_ind
 
+def wavcal_thar(dat, Ni=5, Nx=4, maxiter=10, stdlim=0.005):
+    """wavelegth calibration for ThAr spectrum.
 
-if __name__ == '__main__':
-    # Load a Th-Ar spectrum
-    import pandas as pd
-    from pyird.plot.order import plot_refthar
-    from pyird.io.read_linelist import read_linelist
-    from astropy.io import fits
-    from scipy.signal import medfilt
+    Args:
+        dat: ThAr spectrum (norder x npix matrix)
+        Ni: order of the fitting function arong each echelle order
+        Nx: order of the fitting function with respect to the aperture number
+        maxiter: maximum number of iterations
+        stdlim: When the std of fitting residuals reaches this value, the iteration is terminated.
 
-    import pkg_resources
-    path = (pkg_resources.resource_filename(
-        'pyird', 'data/thar_mmf2_a_H_20210317.fits'))
-    hd = fits.open(path)
-    dat = (hd[0].data)
+    Returns:
+        final results of the wavlength solution
+        data of ThAr signals used for fitting
 
+    Examples:
+        >>> wavsol, data = wavcal_thar(thar)
+    """
     # Load a channel list
     if np.shape(dat)[0] == 21:
         chanfile = (pkg_resources.resource_filename(
             'pyird', 'data/channel_H.list'))
         norder = 21
+        orders = np.arange(104, 83, -1)
         print('H band')
     elif np.shape(dat)[0] > 45:
         chanfile = (pkg_resources.resource_filename(
             'pyird', 'data/channel_YJ.list'))
         norder = np.shape(dat)[0]
+        orders = np.arange(158, 107, -1)
         print('YJ band')
 
     pdat0 = pd.read_csv(chanfile, delimiter=',')
@@ -138,6 +150,10 @@ if __name__ == '__main__':
     l = norder
     offset = 0
     npix = 2048
+
+    # set matrix
+    pixels = np.arange(1, npix+1, 1)
+    X, Y = np.meshgrid(pixels, orders)
 
     # allocate the line positions in pixcoord
     pdat1 = pd.DataFrame([], columns=['ORDER', 'CHANNEL', 'WAVELENGTH'])
@@ -153,6 +169,8 @@ if __name__ == '__main__':
                 paround = 5  # search area
                 plocal_med = max(med[pchan[k]-paround:pchan[k]+paround])
                 pchanlocal_med = np.where(med == plocal_med)[0]
+                if len(pchanlocal_med)==0:
+                    continue
                 pchanlocal_dat = np.where(dat[i, :] == max(
                     dat[i, :][pchanlocal_med]))[0][0]
                 channel_tmp = pchanlocal_dat+1
@@ -160,12 +178,7 @@ if __name__ == '__main__':
                 df_tmp = pd.DataFrame([data], columns=pdat1.columns)
                 pdat1 = pd.concat([pdat1, df_tmp], ignore_index=True)
 
-    data1 = pdat_to_wavmat(pdat1)
-    # set matrix
-    pixels = np.arange(1, npix+1, 1)
-    orders = np.arange(1, l+1-j, 1)
-    X, Y = np.meshgrid(pixels, orders)
-    Ni, Nx = 5, 4
+    data1 = pdat_to_wavmat(pdat1,j,l)
 
     # wavlength solution (rough estimation)
     p1 = fit_wav_solution((X, Y), data1, Ni, Nx)
@@ -180,7 +193,9 @@ if __name__ == '__main__':
     plot_refthar(wavsol1, data1, l-j)
 
     # read thar_ird2.dat
-    wavref = read_linelist('../data/thar_ird2.dat')
+    path = (pkg_resources.resource_filename(
+        'pyird', 'data/thar_ird2.dat'))
+    wavref = read_linelist(path)
 
     # add lines
     pdat2 = pd.DataFrame([], columns=['ORDER', 'CHANNEL', 'WAVELENGTH'])
@@ -195,7 +210,7 @@ if __name__ == '__main__':
         for ref in wavref_order:
             ind = np.searchsorted(wavsol1_order, ref)
             ind_low, ind_upp = max(ind - waround, 0), min(ind+waround+1, npix)
-            if np.nanmax(med[ind_low:ind_upp]) > 15:
+            if np.nanmax(med[ind_low:ind_upp]) > np.nanpercentile(med[med>0], 80):
                 pix_med = np.where(med == np.nanmax(med[ind_low:ind_upp]))[0]
                 pix_dat = np.where(dat[i, :] == max(dat[i, pix_med]))[0][0]
                 pix_tmp = pix_dat + 1
@@ -204,7 +219,7 @@ if __name__ == '__main__':
                 df_tmp = pd.DataFrame([data], columns=pdat2.columns)
                 pdat2 = pd.concat([pdat2, df_tmp], ignore_index=True)
 
-    data2 = pdat_to_wavmat(pdat2)
+    data2 = pdat_to_wavmat(pdat2,j,l)
     # """ # compare previous wav-channel list & new wav-channel list
     fig = plt.figure(figsize=(7, 5))
     ax = fig.add_subplot(111)
@@ -222,23 +237,33 @@ if __name__ == '__main__':
     # """
 
     # iterate fitting polynomial function
-    Ni, Nx = 5, 4
+    #Ni, Nx = 5, 4
     std, iter = 1, 1
-    while (std > 0.005) and (iter < 10):
+    while (std > stdlim) and (iter < maxiter):
         print(iter)
         # reject duplicated channel
         pdat2 = pdat2[~pdat2.duplicated(keep=False, subset='CHANNEL')]
         pdat2 = pdat2.reset_index(drop=True)
-        data2 = pdat_to_wavmat(pdat2)
+        data2 = pdat_to_wavmat(pdat2,j,l)
         p2 = fit_wav_solution((X, Y), data2, Ni, Nx)
         wavsol2 = fitfunc((X, Y), Ni, Nx, p2)
         wavsol2_2d = wavsol2.reshape(npix, l-j)
-        residuals, drop_ind = sigmaclip(data2.T, wavsol2_2d.T)
+        residuals, drop_ind = sigmaclip(data2.T, wavsol2_2d.T,N=1.5)
         std = np.std(residuals)
         print(std)
         iter += 1
         # print(pdat2.iloc[pdat2.index[drop_ind]])
         if len(drop_ind) != 0:
             pdat2 = pdat2.drop(pdat2.index[drop_ind])
+    return wavsol2, data2
 
-    plot_refthar(wavsol2, data2, l-j)
+if __name__ == '__main__':
+    # Load a Th-Ar spectrum
+    path = (pkg_resources.resource_filename(
+        'pyird', 'data/thar_mmf2_a_H_20210317.fits'))
+    hd = fits.open(path)
+    dat = (hd[0].data)
+
+    wavsol2, data2 = wavcal_thar(dat)
+
+    plot_refthar(wavsol2, data2, 21)

--- a/src/pyird/spec/wavcal.py
+++ b/src/pyird/spec/wavcal.py
@@ -30,13 +30,14 @@ def pdat_to_wavmat(pdat, j, l, npix=2048):
     return mat
 
 
-def fitfunc(XY, Ni, Nx, *params):
-    """calculate 2d Legendre series.
+def fitfunc(XY, Ni, Nx, poly='chebyshev',*params):
+    """calculate 2d polynomial series.
 
     Args:
         XY: meshgrid of (pixels, orders)
         Ni: order of the fitting function arong each echelle order
         Nx: order of the fitting function with respect to the aperture number
+        poly: 'chebyshev' or 'legendre' for fitting polynomial series
         params: fitting coefficients
 
     Returns:
@@ -46,7 +47,10 @@ def fitfunc(XY, Ni, Nx, *params):
     m = XY[1][:, 0]
     ms = XY[1]
     p = np.array(params).reshape((Ni, Nx))
-    f = np.polynomial.legendre.leggrid2d(m, pix, p)/ms
+    if poly=='chebyshev':
+        f = np.polynomial.chebyshev.chebgrid2d(m, pix, p)/ms
+    elif poly=='legendre':
+        f = np.polynomial.legendre.leggrid2d(m, pix, p)/ms
     f = f.T
     return f.ravel()
 


### PR DESCRIPTION
The file "examples/python/reduc_thar.py" is an example of the wavelength calibration part of the IRD data reduction. (To run this, some files such as raw fits files of ThAr are needed. Should I put them somewhere?) 
The "wavcal.py" of the previous PR started with a median combined ThAr file, but this example shows the almost whole process from the raw ThAr data to the wavelength calibrated ThAr spectrum. To allow wavelength calibration for arbitrary data, "wavcal.py" has been modified.