### PR TITLE
TraceAperture instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Classes
 
 - fitsset.FitsSet --  sets of fits files 
 - irdstream.Stream2D -- 2D fits stream from raw images
-
+- aperture.TraceAperture -- aperture class for trace
 
 The followings are out dated info.
 

--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -21,6 +21,14 @@ if nap==42:
     flatmedian = flatmedian[::-1,::-1]
 y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
 
+import matplotlib.pyplot as plt
+from pyird.image.mask import trace
+mask=trace(trace_legendre, y0, xmin, xmax, coeff)
+plt.imshow(mask)
+plt.show()
+
+import sys
+sys.exit()
 
 # hotpixel mask
 datadir = pathlib.Path('/home/kawahara/pyird/data/dark/')

--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -4,8 +4,6 @@ from pyird.utils import irdstream
 import pathlib
 from pyird.image.bias import bias_subtract_image
 from pyird.image.hotpix import identify_hotpix
-from pyird.image.trace_function import trace_legendre
-from pyird.image.aptrace import aptrace
 import astropy.io.fits as pyf
 
 # aperture extraction
@@ -14,21 +12,11 @@ anadir = pathlib.Path('/home/kawahara/pyird/data/flat/')
 flat_smf66=irdstream.Stream2D("flat_smf66",datadir,anadir)
 flat_smf66.fitsid=list(range(47224,47246,2)) #no light in the speckle fiber
 flat_smf66.fitsid_increment()
-flatmedian=flat_smf66.immedian()
-cutrow = 1000  ## 501 ~ 1549
-nap = 42 ## 42 for H band, 102 for YJ band
-if nap==42:
-    flatmedian = flatmedian[::-1,::-1]
-y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
+trace_smf66=flat_smf66.aptrace(cutrow = 1000,nap=42)
 
 import matplotlib.pyplot as plt
-from pyird.image.mask import trace
-mask=trace(trace_legendre, y0, xmin, xmax, coeff)
-plt.imshow(mask)
+plt.imshow(trace_smf66.mask())
 plt.show()
-
-import sys
-sys.exit()
 
 # hotpixel mask
 datadir = pathlib.Path('/home/kawahara/pyird/data/dark/')

--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -11,11 +11,11 @@ datadir = pathlib.Path('/home/kawahara/pyird/data/flat/')
 anadir = pathlib.Path('/home/kawahara/pyird/data/flat/')
 flat_smf66=irdstream.Stream2D("flat_smf66",datadir,anadir)
 flat_smf66.fitsid=list(range(47224,47246,2)) #no light in the speckle fiber
-flat_smf66.fitsid_increment()
-trace_smf66=flat_smf66.aptrace(cutrow = 1000,nap=42)
+flat_smf66.fitsid_increment() # when you use H-band
+trace_smf66=flat_smf66.aptrace(cutrow = 1000,nap=42) #TraceAperture instance
 
 import matplotlib.pyplot as plt
-plt.imshow(trace_smf66.mask())
+plt.imshow(trace_smf66.mask()) #apeture mask plot
 plt.show()
 
 # hotpixel mask

--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -21,6 +21,7 @@ if nap==42:
     flatmedian = flatmedian[::-1,::-1]
 y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
 
+
 # hotpixel mask
 datadir = pathlib.Path('/home/kawahara/pyird/data/dark/')
 anadir = pathlib.Path('/home/kawahara/pyird/data/dark/')

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -1,0 +1,39 @@
+"""Class for aperture"""
+
+import sys
+from pyird.image.mask import trace
+
+__all__ = ['TraceAperture']
+
+
+class TraceAperture(object):
+    """aperture instance for trace class
+
+    """    
+    def __init__(self, trace_funcion, y0, xmin, xmax, coeff):
+        """initialization
+        
+        Args:
+            trace_funcion:  trace funcion used in interpolation
+            y0:  y0
+            xmin:  xmin
+            xmax:  xmax
+            coeff:  polinomial coeff
+        
+        """
+        self.trace_funcion = trace_funcion
+        self.y0 = y0
+        self.xmin = xmin
+        self.xmax = xmax
+        self.coeff = coeff
+
+    def mask(self):
+        """mask image
+        
+        Returns:
+            mask image
+
+        """
+        return trace(self.trace_function, self.y0, self.xmin, self.xmax, self.coeff)
+
+    

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -10,18 +10,18 @@ class TraceAperture(object):
     """aperture instance for trace class
 
     """    
-    def __init__(self, trace_funcion, y0, xmin, xmax, coeff):
+    def __init__(self, trace_function, y0, xmin, xmax, coeff):
         """initialization
         
         Args:
-            trace_funcion:  trace funcion used in interpolation
+            trace_function:  trace function used in interpolation
             y0:  y0
             xmin:  xmin
             xmax:  xmax
             coeff:  polinomial coeff
         
         """
-        self.trace_funcion = trace_funcion
+        self.trace_function = trace_function
         self.y0 = y0
         self.xmin = xmin
         self.xmax = xmax

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -2,6 +2,9 @@
 
 from pyird.utils.fitsset import FitsSet
 from pyird.utils import directory_util
+from pyird.image.trace_function import trace_legendre
+from pyird.image.aptrace import aptrace
+from pyird.utils.aperture import TraceAperture
 import astropy.io.fits as pyf
 import numpy as np
 import tqdm
@@ -274,3 +277,21 @@ class Stream2D(FitsSet):
             print('Skipped '+str(skip)+' files because they already exists.')
 
         return ext_noexist, extf_noexist
+
+    def aptrace(self,cutrow = 1000,nap=42):
+        """extract aperture of trace from a median image of current fitsset
+
+        Args:
+            cutrow: cutting criterion
+            nap: number of apertures, nap = 42 ## 42 for H band, 102 for YJ band
+
+        Returns:
+            TraceAperture instance
+
+        """
+        flatmedian=self.immedian()
+        if nap==42:
+            flatmedian = flatmedian[::-1,::-1]
+            y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
+
+        return TraceAperture(trace_legendre, y0, xmin, xmax, coeff)

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -139,7 +139,7 @@ class Stream2D(FitsSet):
             im = hdu.data
             header = hdu.header
             if i==0:
-                mask = trace_from_iraf_trace_file(im, trace_path_list)
+                mask = trace_from_iraf_trace_file(trace_path_list, mask_shape=np.shape(im))
             calim = np.copy(im)  # image for calibration
             calim[mask] = np.nan
             if hotpix_mask is not None:

--- a/tests/io/test_iraf_trace.py
+++ b/tests/io/test_iraf_trace.py
@@ -12,12 +12,12 @@ def test_read_trace_file():
     assert np.sum(y0) == 13517.2013
 
 def test_mask_from_trace_file():
-    im=np.zeros((2048,2048))
     path = (pkg_resources.resource_filename('pyird', 'data/samples/aprefA'))
-    mask=trace_from_iraf_trace_file(im, path)
+    im=np.zeros((2048,2048))
+    mask=trace_from_iraf_trace_file(path)
     im[mask]=1.0
     assert int(np.sum(im))==246366
     
 if __name__ == '__main__':
     test_read_trace_file()
-    test_mask()
+    test_mask_from_trace_file()

--- a/tests/utils/test_aperture.py
+++ b/tests/utils/test_aperture.py
@@ -1,0 +1,22 @@
+import pytest
+from pyird.image.aptrace import aptrace
+from pyird.image.trace_function import trace_legendre
+from pyird.utils.aperture import TraceAperture
+
+def test_aperture():
+    import numpy as np
+    #The following values are computed by test_aptrace.py
+    y0=np.array([98, 198, 298, 398, 498, 598, 698, 798, 898, 998, 1098, 1198, 1298, 1398, 1498, 1598, 1698, 1798, 1898, 1998])
+    xmin=np.array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
+    xmax=np.array([1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999, 1999])
+    coeff=[np.array([ 1.00000000e+00, -4.24474857e-08,  1.43754930e-08]), np.array([ 1.00000000e+00, -1.50951790e-08, -1.47497638e-08]), np.array([1.00000000e+00, 9.85897478e-08, 1.10251354e-07]), np.array([1.00000000e+00, 9.85897478e-08, 1.10251354e-07]), np.array([1.00000000e+00, 9.85897478e-08, 1.10251354e-07]), np.array([ 1.00000000e+00,  1.94637642e-08, -1.63696642e-07]), np.array([ 1.00000000e+00,  1.94637642e-08, -1.63696642e-07]), np.array([ 1.00000000e+00,  1.94637642e-08, -1.63696642e-07]), np.array([ 1.00000000e+00,  1.94637642e-08, -1.63696642e-07]), np.array([ 1.00000000e+00,  1.94637642e-08, -1.63696642e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07]), np.array([ 1.00000000e+00, -6.44062833e-08,  1.82082310e-07])]
+    
+    ta = TraceAperture(trace_legendre, y0, xmin, xmax, coeff)
+#    ta.trace_function = trace_legendre
+    #import matplotlib.pyplot as plt
+    #plt.imshow(ta.mask())
+    #plt.show()
+    assert np.sum(ta.mask()) == 239760
+
+if __name__ == '__main__':
+    test_aperture()


### PR DESCRIPTION
To handle aperture parameter sets, I made TraceAperture instance in utils/aperture.py
Currently,  TraceAperture instance only has `mask` instance, which computes 0-1 binary image for the trace aperture.

For a demo,
```sh
python REACH_stream.py
```

Please check unittests.
```sh
cd tests
pytest
```
