### PR TITLE
IRD stream (ver.1; before wavelength allocation)

### DIFF
--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -51,7 +51,8 @@ anadir = basedir/'thar'
 
 #wavelength calibration
 thar=irdstream.Stream2D("thar",datadir,anadir,rawtag="IRDAD000",fitsid=list(range(14632,14732)))
-thar.trace = trace_mmf.mmf2()
+thar.trace = trace_mmf
+trace_mmf.mmf2() # choose mmf2 (star fiber)
 thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
 wavsol, data=thar.calibrate_wavlength()
 #wavsol_2d = wavsol.reshape((2048,21))

--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -1,0 +1,57 @@
+import numpy as np
+#import pkg_resources
+from pyird.utils import irdstream
+import pathlib
+from pyird.image.bias import bias_subtract_image
+from pyird.image.hotpix import identify_hotpix
+import astropy.io.fits as pyf
+
+# path
+basedir = pathlib.Path('/Users/yuikasagi/IRD/PhDwork/pyird/data/20210317/')
+
+# aperture extraction
+datadir = basedir/'flat/'
+anadir = basedir/'flat/'
+flat_mmf=irdstream.Stream2D("flat_mmf",datadir,anadir)
+flat_mmf.fitsid=list(range(41704,41804,2)) #no light in the speckle fiber
+flat_mmf.fitsid_increment() # when you use H-band
+trace_mmf=flat_mmf.aptrace(cutrow = 1000,nap=42) #TraceAperture instance
+
+import matplotlib.pyplot as plt
+plt.imshow(trace_mmf.mask()) #apeture mask plot
+plt.show()
+
+# hotpixel mask
+datadir = basedir/'dark/'
+anadir = basedir/'dark/'
+dark = irdstream.Stream2D('dark', datadir, anadir)
+dark.fitsid = [41505]
+for data in dark.rawpath:
+    im = pyf.open(str(data))[0].data
+im_subbias = bias_subtract_image(im)
+hotpix_mask, obj = identify_hotpix(im_subbias)
+
+# Load data
+datadir = basedir/'target/'
+anadir = basedir/'target/'
+target = irdstream.Stream2D(
+    'targets', datadir, anadir, fitsid=[41511])
+target.info = True  # show detailed info
+target.trace = trace_mmf
+
+# clean pattern
+target.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+
+# flatten
+target.flatten()
+
+# load ThAr raw image
+datadir = basedir/'thar'
+anadir = basedir/'thar'
+
+#wavelength calibration
+thar=irdstream.Stream2D("thar",datadir,anadir,rawtag="IRDAD000",fitsid=list(range(14632,14732)))
+thar.trace = trace_mmf.mmf2()
+thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+wavsol, data=thar.calibrate_wavlength()
+#wavsol_2d = wavsol.reshape((2048,21))

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -37,6 +37,12 @@ class TraceAperture(object):
         return trace(self.trace_function, self.y0, self.xmin, self.xmax, self.coeff)
 
     def mmf2(self):
+        """choose apertures for mmf2 (star fiber)
+
+        Returns:
+            updated variables (y0, xmin, xmax, coeff)
+
+        """
         self.y0 = self.y0[::2]
         self.xmin = self.xmin[::2]
         self.xmax = self.xmax[::2]

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -41,4 +41,3 @@ class TraceAperture(object):
         self.xmin = self.xmin[::2]
         self.xmax = self.xmax[::2]
         self.coeff = self.coeff[::2]
-        return self

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -9,17 +9,17 @@ __all__ = ['TraceAperture']
 class TraceAperture(object):
     """aperture instance for trace class
 
-    """    
+    """
     def __init__(self, trace_function, y0, xmin, xmax, coeff):
         """initialization
-        
+
         Args:
             trace_function:  trace function used in interpolation
             y0:  y0
             xmin:  xmin
             xmax:  xmax
             coeff:  polinomial coeff
-        
+
         """
         self.trace_function = trace_function
         self.y0 = y0
@@ -29,11 +29,16 @@ class TraceAperture(object):
 
     def mask(self):
         """mask image
-        
+
         Returns:
             mask image
 
         """
         return trace(self.trace_function, self.y0, self.xmin, self.xmax, self.coeff)
 
-    
+    def mmf2(self):
+        self.y0 = self.y0[::2]
+        self.xmin = self.xmin[::2]
+        self.xmax = self.xmax[::2]
+        self.coeff = self.coeff[::2]
+        return self


### PR DESCRIPTION
I tried to create the example code of the data reduction stream for IRD data (because I didn't have the REACH dataset.)
This first version includes extracting apertures and wavelength calibration, but not yet the wavelength allocation.

To avoid using the IRAF file, I have modified `irdstream.py` slightly. So please check if it is ok or if there is another better way (such as saving trace files like IRAF??).