### PR TITLE
IRD stream (ver.2; wavelength calibrated 1d spectrum)

### DIFF
--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -54,5 +54,7 @@ thar=irdstream.Stream2D("thar",datadir,anadir,rawtag="IRDAD000",fitsid=list(rang
 thar.trace = trace_mmf
 trace_mmf.mmf2() # choose mmf2 (star fiber)
 thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
-wavsol, data=thar.calibrate_wavlength()
-#wavsol_2d = wavsol.reshape((2048,21))
+thar.calibrate_wavlength()
+
+# assign reference spectra & resample
+target.dispcor('_fl','w')


### PR DESCRIPTION
The assignment of wavelength to the extracted 1D spectrum is implemented in `IRD_stream.py`.
It will be saved as a text file named "w?????_m2.dat." ($1: wavelength, $2: order, $3: flux (ADU))

In the next update (ver.3), I'm going to add functions to normalize the 1D spectrum by the blaze function. #38 