### PR TITLE
preparation for application to the YJ band

### DIFF
--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -13,10 +13,18 @@ basedir = pathlib.Path('~/pyird/data/20210317/').expanduser()
 # aperture extraction
 datadir = basedir/'flat/'
 anadir = basedir/'flat/'
-flat_mmf=irdstream.Stream2D("flat_mmf",datadir,anadir)
-flat_mmf.fitsid=list(range(41704,41804,2)) #no light in the speckle fiber
-flat_mmf.fitsid_increment() # when you use H-band
-trace_mmf=flat_mmf.aptrace(cutrow = 1000,nap=42) #TraceAperture instance
+flat=irdstream.Stream2D("flat",datadir,anadir)
+flat.fitsid=list(range(41704,41804,2))
+################################
+### SELECT H band or YJ band ###
+################################
+flat.band='h' #'h' or 'y'
+print(flat.band,' band')
+if flat.band=='h':
+    flat.fitsid_increment() # when you use H-band
+    trace_mmf=flat.aptrace(cutrow = 1500,nap=42) #TraceAperture instance
+elif flat.band=='y':
+    trace_mmf=flat.aptrace(cutrow = 1000,nap=102) #TraceAperture instance
 
 import matplotlib.pyplot as plt
 plt.imshow(trace_mmf.mask()) #apeture mask plot
@@ -25,21 +33,31 @@ plt.show()
 # hotpixel mask
 datadir = basedir/'dark/'
 anadir = basedir/'dark/'
-dark = irdstream.Stream2D('dark', datadir, anadir)
-dark.fitsid = [41505]
+dark = irdstream.Stream2D('dark', datadir, anadir,fitsid=[41504])
+if flat.band=='h':
+    dark.fitsid_increment() # when you use H-band
 for data in dark.rawpath:
     im = pyf.open(str(data))[0].data
 im_subbias = bias_subtract_image(im)
 hotpix_mask, obj = identify_hotpix(im_subbias)
 
+###########################
+### SELECT mmf2 or mmf1 ###
+###########################
+trace_mmf.mmf2() #mmf2 (star fiber)
+#trace_mmf.mmf1() #mmf1 (comb fiber)
+
 # load ThAr raw image
 datadir = basedir/'thar'
 anadir = basedir/'thar'
+if flat.band=='h':
+    rawtag='IRDAD000'
+elif flat.band=='y':
+    rawtag='IRDBD000'
 
 #wavelength calibration
-thar=irdstream.Stream2D("thar",datadir,anadir,rawtag="IRDAD000",fitsid=list(range(14632,14732)))
+thar=irdstream.Stream2D("thar",datadir,anadir,rawtag=rawtag,fitsid=list(range(14632,14732)))
 thar.trace = trace_mmf
-trace_mmf.mmf2() # choose mmf2 (star fiber)
 thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
 thar.calibrate_wavlength()
 
@@ -48,7 +66,9 @@ thar.calibrate_wavlength()
 datadir = basedir/'target/'
 anadir = basedir/'target/'
 target = irdstream.Stream2D(
-    'targets', datadir, anadir, fitsid=[41511])
+    'targets', datadir, anadir, fitsid=[41510])
+if flat.band=='h':
+    target.fitsid_increment() # when you use H-band
 target.info = True  # show detailed info
 target.trace = trace_mmf
 # clean pattern
@@ -59,22 +79,46 @@ target.flatten()
 target.dispcor()
 
 ### FLAT (for blaze function) ###
-flat_mmf.trace = trace_mmf
-flat_mmf.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
-flat_mmf.imcomb = True # median combine
-flat_mmf.flatten()
-flat_mmf.dispcor()
+flat.trace = trace_mmf
+if flat.band == 'h':
+    flat.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+flat.imcomb = True # median combine
+flat.flatten()
+flat.dispcor()
 
 # combine & normalize
-target.normalize1D(flatid=flat_mmf.streamid)
+target.normalize1D(flatid=flat.streamid)
 
 """### mmfmmf (test) ###
 datadir = basedir/'mmfmmf/'
 anadir = basedir/'mmfmmf/'
-mmfmmf=irdstream.Stream2D("mmfmmf",datadir,anadir,rawtag="IRDAD000",fitsid=list(range(14733,14833)))
+mmfmmf=irdstream.Stream2D("mmfmmf",datadir,anadir,rawtag=rawtag,fitsid=list(range(15106,15206)))
 mmfmmf.trace = trace_mmf
-mmfmmf.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+mmfmmf.clean_pattern(extin='', extout='_cp')#, hotpix_mask=hotpix_mask)
 mmfmmf.imcomb = True
 mmfmmf.flatten()
 mmfmmf.dispcor()
+mmfmmf.normalize1D()
+
+### hotpix (test) ###
+dark.trace = trace_mmf
+dark.flatten()
+#dark.dispcor()
+import pandas as pd
+input = basedir/'dark/IRDA00046425_fl_m2.fits' ## check!!!
+hdu = pyf.open(input)[0]
+spec_m2 = hdu.data
+wspec = pd.DataFrame([],columns=['wav','order','flux'])
+for i in range(len(spec_m2[0])):
+    wav = range(1,2049)#reference[:,i]
+    order = np.ones(len(wav))
+    order[:] = i+1
+    data_order = [wav,order,spec_m2[:,i]]
+    df_order = pd.DataFrame(data_order,index=['wav','order','flux']).T
+    wspec = pd.concat([wspec,df_order])
+wspec = wspec.fillna(0)
+save_path = basedir/'dark/w46425_m2.dat'
+wspec.to_csv(save_path,header=False,index=False,sep=' ')
+
+#dark.normalize1D()
 """

--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -59,7 +59,7 @@ elif flat.band=='y':
 thar=irdstream.Stream2D("thar",datadir,anadir,rawtag=rawtag,fitsid=list(range(14632,14732)))
 thar.trace = trace_mmf
 thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
-thar.calibrate_wavlength()
+thar.calibrate_wavelength()
 
 ### TARGET ###
 # Load data

--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -18,7 +18,13 @@ def flatten(im, trace_func, y0, xmin, xmax, coeff):
        raw multiorder spectra
        multiorder pixel coordinate
     """
-    rotim = np.copy(im[::-1, ::-1])
+
+    if len(y0)==21: #h band
+        rotim = np.copy(im[::-1, ::-1])
+        end = 2
+    elif len(y0)==51: # yj band
+        rotim = np.copy(im)
+        end = 1
 
     x = []
     for i in range(len(y0)):
@@ -34,7 +40,7 @@ def flatten(im, trace_func, y0, xmin, xmax, coeff):
         eachpixcoord = []
         for j, ix in enumerate(x[i]):
             iys = np.max([0, tl_tmp[j]-width])
-            iye = np.min([ny, tl_tmp[j]+width+2])
+            iye = np.min([ny, tl_tmp[j]+width+end])  #do not change!: to avoid flux extracting
             eachspec.append(np.sum(rotim[ix, iys:iye]))
             eachpixcoord.append(ix)
         spec.append(eachspec)

--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -40,7 +40,7 @@ def flatten(im, trace_func, y0, xmin, xmax, coeff):
         eachpixcoord = []
         for j, ix in enumerate(x[i]):
             iys = np.max([0, tl_tmp[j]-width])
-            iye = np.min([ny, tl_tmp[j]+width+end])  #do not change!: to avoid flux extracting
+            iye = np.min([ny, tl_tmp[j]+width+end])  #do not change!: to avoid flux extraction failure
             eachspec.append(np.sum(rotim[ix, iys:iye]))
             eachpixcoord.append(ix)
         spec.append(eachspec)

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -26,6 +26,7 @@ class TraceAperture(object):
         self.xmin = xmin
         self.xmax = xmax
         self.coeff = coeff
+        self.mmf = 'mmf12'
 
     def mask(self):
         """mask image
@@ -47,3 +48,17 @@ class TraceAperture(object):
         self.xmin = self.xmin[::2]
         self.xmax = self.xmax[::2]
         self.coeff = self.coeff[::2]
+        self.mmf = 'm2'
+
+    def mmf1(self):
+        """choose apertures for mmf1 (comb fiber)
+
+        Returns:
+            updated variables (y0, xmin, xmax, coeff)
+
+        """
+        self.y0 = self.y0[1::2]
+        self.xmin = self.xmin[1::2]
+        self.xmax = self.xmax[1::2]
+        self.coeff = self.coeff[1::2]
+        self.mmf = 'm1'

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -32,6 +32,10 @@ class Stream2D(FitsSet):
         if fitsid is not None:
             print('fitsid:', fitsid)
             self.fitsid = fitsid
+            if (rawtag=='IRDA000' and fitsid[0]%2==0) or (rawtag=='IRDBD000'):
+                self.band = 'y'
+            else:
+                self.band = 'h'
         else:
             print('No fitsid yet.')
 
@@ -49,6 +53,7 @@ class Stream2D(FitsSet):
         for i in range(0, len(self.fitsid)):
             self.fitsid[i] = self.fitsid[i]+1
         self.rawpath = self.path(string=False, check=True)
+        self.band = 'h'
 
     def fitsid_decrement(self):
         """Decrease fits id +1."""
@@ -177,16 +182,20 @@ class Stream2D(FitsSet):
 
         currentdir = os.getcwd()
         os.chdir(str(self.anadir))
-        if self.info:
-            print('flatten: output extension=', extout)
 
         if trace_path is None:
             y0, xmin, xmax, coeff = self.trace.y0, self.trace.xmin, self.trace.xmax, self.trace.coeff
+            mmf = self.trace.mmf
         else:
             y0, interp_function, xmin, xmax, coeff = read_trace_file(trace_path)
 
         if extin is None:
             extin = self.extension
+
+        extout = extout + '_' + mmf
+
+        if self.info:
+            print('flatten: output extension=', extout)
 
         if not self.imcomb:
             extin_noexist, extout_noexist = self.check_existence(extin, extout)
@@ -210,7 +219,7 @@ class Stream2D(FitsSet):
             rsd = multiorder_to_rsd(rawspec, pixcoord)
             hdux = pyf.PrimaryHDU(rsd, header)
             hdulist = pyf.HDUList([hdux])
-            save_path = self.anadir/('%s_mmf12.fits'%(self.streamid))
+            save_path = self.anadir/('%s_mmf12_%s.fits'%(self.streamid,self.band))
             hdulist.writeto(save_path, overwrite=True)
         self.fitsdir = self.anadir
         self.extension = extout
@@ -230,12 +239,11 @@ class Stream2D(FitsSet):
         median_image = np.nanmedian(imall, axis=0)
         return median_image
 
-    def calibrate_wavlength(self, trace_file_path=None, master='thar_master.fits' ,maxiter=30, stdlim=0.001, npix=2048):
+    def calibrate_wavlength(self, trace_file_path=None, maxiter=30, stdlim=0.001, npix=2048):
         """wavelength calibration usgin Th-Ar.
 
         Args:
            trace_file_path: path to the trace file
-           master: master file for the wavelength calibrated ThAr file
            maxiter: maximum number of iterations
            stdlim: When the std of fitting residuals reaches this value, the iteration is terminated.
            npix: number of pixels
@@ -254,10 +262,11 @@ class Stream2D(FitsSet):
 
         if trace_file_path is None:
             y0, xmin, xmax, coeff = self.trace.y0, self.trace.xmin, self.trace.xmax, self.trace.coeff
+            mmf = self.trace.mmf
         else:
             y0, interp_function, xmin, xmax, coeff = read_trace_file(trace_file_path)
 
-        master_path = master
+        master_path = 'thar_%s_%s.fits'%(self.band,mmf)
         if not os.path.exists(master_path):
             filen = self.path()[0] #header of the first file
             hdu = pyf.open(filen)[0]
@@ -326,13 +335,13 @@ class Stream2D(FitsSet):
 
         """
         flatmedian=self.immedian()
-        if nap==42:
+        if nap==42 or nap==21:
             flatmedian = flatmedian[::-1,::-1]
-            y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
+        y0, xmin, xmax, coeff = aptrace(flatmedian,cutrow,nap)
 
         return TraceAperture(trace_legendre, y0, xmin, xmax, coeff)
 
-    def dispcor(self, input_ext='_fl', prefix='w', master='thar_master.fits',master_path=None):
+    def dispcor(self, input_ext='_fl', prefix='w', master_path=None):
         """dispersion correct and resample spectra
 
         Args:
@@ -353,11 +362,14 @@ class Stream2D(FitsSet):
                 data_order = [wav,order,spec_m2[:,i]]
                 df_order = pd.DataFrame(data_order,index=['wav','order','flux']).T
                 wspec = pd.concat([wspec,df_order])
+            wspec = wspec.fillna(0)
             wspec.to_csv(save_path,header=False,index=False,sep=' ')
             return wspec
 
         if master_path==None:
-            master_path = self.anadir.joinpath('..','thar').resolve()/master
+            master_path = self.anadir.joinpath('..','thar').resolve()/('thar_%s_%s.fits'%(self.band,self.trace.mmf))
+
+        input_ext = input_ext + '_' + self.trace.mmf
 
         if not self.imcomb:
             inputs = self.extpath(input_ext,string=False, check=True)
@@ -370,44 +382,49 @@ class Stream2D(FitsSet):
                 reference = hdu.data
 
                 id = self.fitsid[j]
-                save_path = self.anadir/('%s%d_m2.dat'%(prefix,id)) ##for mmf2
+                save_path = self.anadir/('%s%d_%s.dat'%(prefix,id,self.trace.mmf)) ##e.g. w41511_m2.dat
                 wspec = mkwspec(spec_m2,reference,save_path)
                 if self.info:
-                    print('dispcor: output spectrum= %s%d_m2.dat'%(prefix,id))
+                    print('dispcor: output spectrum= %s%d_%s.dat'%(prefix,id,self.trace.mmf))
                 #plot
                 show_wavcal_spectrum(wspec,alpha=0.5)
         else:
-            hdu = pyf.open(self.anadir/('%s_mmf12.fits'%(self.streamid)))[0]
+            hdu = pyf.open(self.anadir/('%s_mmf12_%s.fits'%(self.streamid,self.band)))[0]
             spec_m12 = hdu.data
             spec_m2 = spec_m12#[:,::2] # choose mmf2 (star fiber)
 
             hdu = pyf.open(master_path)[0]
             reference = hdu.data
 
-            save_path = self.anadir/('%s%s_m2.dat'%(prefix,self.streamid))
+            save_path = self.anadir/('%s%s_%s_%s.dat'%(prefix,self.streamid,self.band,self.trace.mmf))
             wspec = mkwspec(spec_m2,reference,save_path)
             if self.info:
-                print('dispcor: output spectrum= %s%s_m2.dat'%(prefix,self.streamid))
+                print('dispcor: output spectrum= %s%s_%s_%s.dat'%(prefix,self.streamid,self.band,self.trace.mmf))
             #plot
             show_wavcal_spectrum(wspec,alpha=0.5)
 
-    def normalize1D(self,flatid='flat'):
+    def normalize1D(self,flatid='flat',master_ext='h'):
         """combine orders and normalize spectrum
 
         Args:
             flatid: streamid for flat data
+            master_ext: h or y (band)
 
         """
         from pyird.spec.continuum import comb_norm
         from pyird.plot.showspec import show_wavcal_spectrum
         for id in self.fitsid:
-            wfile = self.anadir/('w%d_m2.dat'%(id))
-            flatfile = self.anadir.joinpath('..','flat').resolve()/('w%s_m2.dat'%(flatid))
-            df_interp = comb_norm(wfile,flatfile)
-            df_save = df_interp[['wav','nflux']]
-            save_path = self.anadir/('ncw%d_m2.dat'%(id))
-            df_save.to_csv(save_path,header=False,index=False,sep=' ')
+            wfile = self.anadir/('w%d_%s.dat'%(id,self.trace.mmf))#('wmmfmmf_%s_%s.dat'%(self.band,self.trace.mmf))#
+            flatfile = self.anadir.joinpath('..','flat').resolve()/('w%s_%s_%s.dat'%(flatid,self.band,self.trace.mmf))
+            df_continuum, df_interp = comb_norm(wfile,flatfile)
+            df_continuum_save = df_continuum[['wav','order','nflux']]
+            df_interp_save = df_interp[['wav','nflux']]
+            nwsave_path = self.anadir/('nw%d_%s.dat'%(id,self.trace.mmf))
+            ncwsave_path = self.anadir/('ncw%d_%s.dat'%(id,self.trace.mmf))
+            df_continuum_save.to_csv(nwsave_path,header=False,index=False,sep=' ')
+            df_interp_save.to_csv(ncwsave_path,header=False,index=False,sep=' ')
             if self.info:
-                print('normalize1D: output normalized 1D spectrum= ncw%d_m2.dat'%(id))
+                print('normalize1D: output normalized 1D spectrum= nw and ncw%d_%s.dat'%(id,self.trace.mmf))
             #plot
-            show_wavcal_spectrum(df_save,alpha=0.5)
+            show_wavcal_spectrum(df_continuum_save,alpha=0.5)
+            show_wavcal_spectrum(df_interp_save,alpha=0.5)

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -219,7 +219,7 @@ class Stream2D(FitsSet):
             rsd = multiorder_to_rsd(rawspec, pixcoord)
             hdux = pyf.PrimaryHDU(rsd, header)
             hdulist = pyf.HDUList([hdux])
-            save_path = self.anadir/('%s_mmf12_%s.fits'%(self.streamid,self.band))
+            save_path = self.anadir/('%s_%s_%s.fits'%(self.streamid,self.band,mmf))
             hdulist.writeto(save_path, overwrite=True)
         self.fitsdir = self.anadir
         self.extension = extout
@@ -389,7 +389,7 @@ class Stream2D(FitsSet):
                 #plot
                 show_wavcal_spectrum(wspec,alpha=0.5)
         else:
-            hdu = pyf.open(self.anadir/('%s_mmf12_%s.fits'%(self.streamid,self.band)))[0]
+            hdu = pyf.open(self.anadir/('%s_%s_%s.fits'%(self.streamid,self.band,self.trace.mmf)))[0]
             spec_m12 = hdu.data
             spec_m2 = spec_m12#[:,::2] # choose mmf2 (star fiber)
 

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -239,7 +239,7 @@ class Stream2D(FitsSet):
         median_image = np.nanmedian(imall, axis=0)
         return median_image
 
-    def calibrate_wavlength(self, trace_file_path=None, maxiter=30, stdlim=0.001, npix=2048):
+    def calibrate_wavelength(self, trace_file_path=None, maxiter=30, stdlim=0.001, npix=2048):
         """wavelength calibration usgin Th-Ar.
 
         Args:

--- a/tests/spec/test_continuum.py
+++ b/tests/spec/test_continuum.py
@@ -5,7 +5,7 @@ from pyird.spec.continuum import comb_norm
 def test_normalize1D():
     import numpy as np
     flat_path = (pkg_resources.resource_filename('pyird', 'data/samples/wflat_m2_20210317.dat'))
-    df_interp = comb_norm(flat_path,flat_path)
+    _, df_interp = comb_norm(flat_path,flat_path)
     nflux = df_interp['nflux']
     assert round(np.mean(nflux))==1
 


### PR DESCRIPTION
Some instance variables have been added to treat YJ band or mmf1 (comb fiber) data. (See IRD_stream.py for usage.)

memo:
** The reduction process is NOT YET optimized for YJ band data.
**  The problem of setting the appropriate path for the data (e.g. the reference path of the master ThAr file) is NOT YET resolved.
The above things will be resolved in the future.