### PR TITLE
minor fix of the trace mask for clean_pattern

### DIFF
--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -25,6 +25,7 @@ if flat.band=='h':
     trace_mmf=flat.aptrace(cutrow = 800,nap=42) #TraceAperture instance
 elif flat.band=='y':
     trace_mmf=flat.aptrace(cutrow = 1000,nap=102) #TraceAperture instance
+trace_mask = trace_mmf.mask()
 
 import matplotlib.pyplot as plt
 plt.imshow(trace_mmf.mask()) #apeture mask plot
@@ -57,7 +58,7 @@ elif flat.band=='y':
 #wavelength calibration
 thar=irdstream.Stream2D("thar",datadir,anadir,rawtag=rawtag,fitsid=list(range(14632,14732)))
 thar.trace = trace_mmf
-thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+thar.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 thar.calibrate_wavelength()
 
 ### TARGET ###
@@ -71,7 +72,7 @@ if flat.band=='h':
 target.info = True  # show detailed info
 target.trace = trace_mmf
 # clean pattern
-target.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+target.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 # flatten
 target.flatten()#hotpix_mask=hotpix_mask)
 # assign reference spectra & resample
@@ -80,7 +81,7 @@ target.dispcor(master_path=thar.anadir)#,extin='_hp')
 ### FLAT (for blaze function) ###
 flat.trace = trace_mmf
 if flat.band == 'h':
-    flat.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+    flat.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 flat.imcomb = True # median combine
 flat.flatten()
 flat.dispcor(master_path=thar.anadir)
@@ -95,7 +96,7 @@ datadir = basedir/'mmfmmf/'
 anadir = basedir/'reduc_rv/'
 mmfmmf=irdstream.Stream2D("mmfmmf",datadir,anadir,fitsid=list(range(14734,14832)),rawtag=rawtag)
 mmfmmf.trace = trace_mmf
-mmfmmf.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+mmfmmf.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 mmfmmf.imcomb = True
 mmfmmf.flatten()
 mmfmmf.dispcor(master_path=thar.anadir)

--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -28,12 +28,13 @@ if flat.band=='h':
     trace_smf=flat.aptrace(cutrow = 800,nap=42) #TraceAperture instance
 elif flat.band=='y':
     trace_smf=flat.aptrace(cutrow = 1000,nap=102) #TraceAperture instance
+trace_mask = trace_smf.mask()
 
 import matplotlib.pyplot as plt
 plt.imshow(trace_smf.mask()) #apeture mask plot
 plt.show()
 
-# hotpixel mask: See pyird/io/read_hotpix.py for reading fixed mask (Optional) 
+# hotpixel mask: See pyird/io/read_hotpix.py for reading fixed mask (Optional)
 datadir = basedir/'dark/'
 anadir = basedir/'dark/'
 dark = irdstream.Stream2D('dark', datadir, anadir,fitsid=[47269],inst=inst)
@@ -62,7 +63,7 @@ elif flat.band=='y':
 #wavelength calibration
 thar=irdstream.Stream2D("thar",datadir,anadir,fitsid=list(range(53347,53410,2)),inst=inst)
 thar.trace = trace_smf
-thar.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+thar.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 thar.calibrate_wavelength()
 
 ### TARGET ###
@@ -76,7 +77,7 @@ if flat.band=='h':
 target.info = True  # show detailed info
 target.trace = trace_smf
 # clean pattern
-target.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+target.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 # flatten
 target.flatten(hotpix_mask=hotpix_mask)
 # assign reference spectra & resample
@@ -85,7 +86,7 @@ target.dispcor(master_path=thar.anadir,extin='_hp')
 ### FLAT (for blaze function) ###
 flat.trace = trace_smf
 if flat.band == 'h':
-    flat.clean_pattern(extin='', extout='_cp', hotpix_mask=hotpix_mask)
+    flat.clean_pattern(trace_mask=trace_mask,extin='', extout='_cp', hotpix_mask=hotpix_mask)
 flat.imcomb = True # median combine
 flat.flatten()
 flat.dispcor(master_path=thar.anadir)

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -28,6 +28,7 @@ class TraceAperture(object):
         self.coeff = coeff
         self.mmf = 'mmf12'
         self.inst = inst
+        self.info = False
 
     def mask(self):
         """mask image
@@ -36,6 +37,8 @@ class TraceAperture(object):
             mask image
 
         """
+        if self.info:
+            print('trace_mask used: ',self.mmf)
         return trace(self.trace_function, self.y0, self.xmin, self.xmax, self.coeff, inst=self.inst)
 
     def mmf2(self):

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -123,28 +123,26 @@ class Stream2D(FitsSet):
         self.fitsdir = self.anadir
         self.extension = '_rb'
 
-    def clean_pattern(self, trace_path_list=None, hotpix_mask=None, extout='_cp', extin=None):
+    def clean_pattern(self, trace_mask=None, hotpix_mask=None, extout='_cp', extin=None):
         """
 
         Args:
-           trace_path_list: path list of trace files
+           trace_mask: trace mask (from iraf, use image.mask.trace_from_iraf_trace_file)
            hotpix_mask: hot pixel mask
            extout: output extension
            extin: input extension
 
         """
         from pyird.image.pattern_model import median_XY_profile
-        from pyird.image.mask import trace_from_iraf_trace_file
+        #from pyird.image.mask import trace_from_iraf_trace_file
 
         currentdir = os.getcwd()
         os.chdir(str(self.anadir))
         if self.info:
             print('clean_pattern: output extension=', extout)
 
-        if trace_path_list is None:
-            mask = self.trace.mask()
-        else:
-            mask = trace_from_iraf_trace_file(trace_path_list)
+        if trace_mask is None:
+            trace_mask = self.trace.mask()
 
         if extin is None:
             extin = self.extension
@@ -157,7 +155,7 @@ class Stream2D(FitsSet):
             im = hdu.data
             header = hdu.header
             calim = np.copy(im)  # image for calibration
-            calim[mask] = np.nan
+            calim[trace_mask] = np.nan
             if hotpix_mask is not None:
                 calim[hotpix_mask] = np.nan
             model_im = median_XY_profile(calim, show=False)


### PR DESCRIPTION
I noticed that the aperture trace mask used for `clean_pattern` in the current pipeline was not appropriate, and it resulted in a slight overestimation of the scattered light to be removed.
The problem was that only one aperture was masked when applying `clean_pattern`, so the light from another fiber prevents to estimate of a true readout noise model in the current pipeline (before fixed).

Therefore, I changed the stream to use the desired aperture trace mask.