### PR TITLE
Correct the wavelength grid when combining the flux of adjacent orders

### DIFF
--- a/src/pyird/spec/continuum.py
+++ b/src/pyird/spec/continuum.py
@@ -104,22 +104,26 @@ def normalize(df_continuum):
     for order in orders:
         df_form = df_continuum[df_continuum['order']==order]
         df_latt = df_continuum[df_continuum['order']==(int(order)+1)]
-        wav_tail = df_form['wav'].values[-1]
+        #cut +2/-10 pix from the zero flux region at the edge of the order
+        ind_nzflux_form = np.where(df_form.flux!=0)[0]
+        ind_nzflux_latt = np.where(df_latt.flux!=0)[0]
+        df_form = df_form[min(ind_nzflux_form)+2:max(ind_nzflux_form)-9]
         try:
-            wav_head = df_latt['wav'].values[0]
+            df_latt = df_latt[min(ind_nzflux_latt)+2:max(ind_nzflux_latt)-9]
         except:
-            wav_head = None
+            pass
+
         if order==min(orders):
+            wav_tail = df_form['wav'].values[-1]
+            wav_head = df_latt['wav'].values[0]
             df_interp = pd.concat([df_interp,df_form[df_form['wav']<wav_head][df_interp.columns]])
         elif order==max(orders):
             add_ind = (df_form['wav']>df_interp['wav'].values[-1])
             df_interp = pd.concat([df_interp,df_form[add_ind][df_interp.columns]])
             continue
         else:
-            ind_nzflux_form = np.where(df_form.flux!=0)[0]
-            ind_nzflux_latt = np.where(df_latt.flux!=0)[0]
-            df_form = df_form[min(ind_nzflux_form)+2:max(ind_nzflux_form)-9] #+2/-10 pix around the edge of an order (flux=0)
-            df_latt = df_latt[min(ind_nzflux_latt)+2:max(ind_nzflux_latt)-9]
+            wav_tail = df_form['wav'].values[-1]
+            wav_head = df_latt['wav'].values[0]
             add_ind = (df_form['wav']>df_interp['wav'].values[-1]) & (df_form['wav']<wav_head)
             df_interp = pd.concat([df_interp,df_form[add_ind][df_interp.columns]])
         df_head = df_latt[df_latt['wav']<=wav_tail]


### PR DESCRIPTION
I think this can fix the problem of issue #65 

I have changed the order of the code for the part that limits wavelengths.