### PR TITLE
Add a new class Stream1D and the function for fringe removal in REACH spectrum

### DIFF
--- a/examples/python/REACH_stream.py
+++ b/examples/python/REACH_stream.py
@@ -24,7 +24,7 @@ flat.fitsid=list(range(53235,53334,2)) #no light in the speckle fiber
 flat.band='h' #'h' or 'y'
 print(flat.band,' band')
 if flat.band=='h':
-    flat.fitsid_increment() # when you use H-band
+    #flat.fitsid_increment() # when you use H-band
     trace_smf=flat.aptrace(cutrow = 800,nap=42) #TraceAperture instance
 elif flat.band=='y':
     trace_smf=flat.aptrace(cutrow = 1000,nap=102) #TraceAperture instance
@@ -38,8 +38,8 @@ plt.show()
 datadir = basedir/'dark/'
 anadir = basedir/'dark/'
 dark = irdstream.Stream2D('dark', datadir, anadir,fitsid=[47269],inst=inst)
-if flat.band=='h':
-    dark.fitsid_increment() # when you use H-band
+#if flat.band=='h':
+#    dark.fitsid_increment() # when you use H-band
 median_image = dark.immedian()
 for data in dark.rawpath:
     im = pyf.open(str(data))[0].data
@@ -72,8 +72,8 @@ datadir = basedir/'target/'
 anadir = basedir/'target/'
 target = irdstream.Stream2D(
     'targets', datadir, anadir, fitsid=[53205],inst=inst)
-if flat.band=='h':
-    target.fitsid_increment() # when you use H-band
+#if flat.band=='h':
+#    target.fitsid_increment() # when you use H-band
 target.info = True  # show detailed info
 target.trace = trace_smf
 # clean pattern

--- a/examples/python/REACH_stream1D.py
+++ b/examples/python/REACH_stream1D.py
@@ -1,7 +1,7 @@
 from pyird.utils import irdstream
 import pathlib
 
-basedir = pathlib.Path('~/IRD/PhDwork/pyird/data/20211110_REACH/').expanduser()
+basedir = pathlib.Path('~/pyird/data/20211110_REACH/').expanduser()
 
 datadir=basedir/'reduc'
 anadir=basedir/'reduc'

--- a/examples/python/REACH_stream1D.py
+++ b/examples/python/REACH_stream1D.py
@@ -1,0 +1,13 @@
+from pyird.utils import irdstream
+import pathlib
+
+basedir = pathlib.Path('~/IRD/PhDwork/pyird/data/20211110_REACH/').expanduser()
+
+datadir=basedir/'reduc'
+anadir=basedir/'reduc'
+target_dat = irdstream.Stream1D("HR37635",datadir,anadir,prefix='nw', extension='_m2')
+target_dat.fitsid=[53205]
+target_dat.band='h'
+#target_dat.fitsid_increment()
+target_dat.date='20211110'
+target_dat.remove_fringe()

--- a/src/pyird/utils/datset.py
+++ b/src/pyird/utils/datset.py
@@ -1,0 +1,66 @@
+"""Set of dat files."""
+
+import sys
+__all__ = ['DatSet']
+
+
+class DatSet(object):
+
+    def __init__(self, dir, prefix='', extension=''):
+        self.prefix = prefix
+        self.extension = extension
+        self.dir = dir
+        self.fitsid = None
+        self.unlock = True  # unlock for cleanning (i.e. remove)
+        self.not_ignore_warning = True
+
+    def path(self, string=False, check=True):
+        """get path array.
+
+        Returns:
+            array of paths
+        """
+        datarray = []
+        if self.fitsid is not None:
+            for num in self.fitsid:
+                d = self.dir/(self.prefix+str(num)+self.extension+'.dat')
+                if check and not d.exists():
+                    print(d, 'does not exist.')
+                    if self.not_ignore_warning:
+                        print(
+                            'If you wanna proceed despite this warning, set self.not_ignore_warning = False in your fitsset.')
+                        sys.exit('Error.')
+                else:
+                    if string:
+                        datarray.append(str(d))
+                    else:
+                        datarray.append(d)
+        return datarray
+
+    def flatpath(self, string=False, check=True):
+        """get path for the normalized flat.
+
+        Returns:
+            path for the normalized flat
+        """
+
+        d = self.dir/('nwflat_'+self.band+self.extension+'.dat')
+        if check and not d.exists():
+            print(d, 'does not exist.')
+            if self.not_ignore_warning:
+                print(
+                    'If you wanna proceed despite this warning, set self.not_ignore_warning = False in your fitsset.')
+                sys.exit('Error.')
+        else:
+            if string:
+                d = str(d)
+        return d
+
+    def clean(self):
+        """Clean i.e. remove files if exists."""
+        import os
+        if self.unlock:
+            for i in range(len(self.path())):
+                if self.path(check=False)[i].exists():
+                    os.remove(self.path(check=False, string=True)[i])
+                    print('rm old '+self.path(check=False, string=True)[i])

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -1,12 +1,14 @@
 """File stream for IRD analysis."""
 
 from pyird.utils.fitsset import FitsSet
+from pyird.utils.datset import DatSet
 from pyird.utils import directory_util
 from pyird.image.trace_function import trace_legendre
 from pyird.image.aptrace import aptrace
 from pyird.utils.aperture import TraceAperture
 import astropy.io.fits as pyf
 import numpy as np
+import pandas as pd
 import tqdm
 import os
 
@@ -465,7 +467,6 @@ class Stream2D(FitsSet):
         """
         from pyird.plot.showspec import show_wavcal_spectrum
         def mkwspec(spec_m2,reference,save_path):
-            import pandas as pd
             wspec = pd.DataFrame([],columns=['wav','order','flux'])
             for i in range(len(reference[0])):
                 wav = reference[:,i]
@@ -538,7 +539,7 @@ class Stream2D(FitsSet):
         else:
             fits_range = self.fitsid
 
-        for id in fits_range:
+        for i,id in enumerate(fits_range):
             if self.imcomb:
                 wfile = self.anadir/('wmmfmmf_%s_%s.dat'%(self.band,self.trace.mmf))
                 nwsave_path = self.anadir/('nwmmfmmf_%s_%s.dat'%(self.band,self.trace.mmf))
@@ -552,8 +553,121 @@ class Stream2D(FitsSet):
             df_interp_save = df_interp[['wav','nflux']]
             df_continuum_save.to_csv(nwsave_path,header=False,index=False,sep=' ')
             df_interp_save.to_csv(ncwsave_path,header=False,index=False,sep=' ')
+            if i==0:
+                nflatsave_path = self.anadir/('nwflat_%s_%s.dat'%(self.band,self.trace.mmf))
+                df_continuum_nflat = df_continuum[['wav','order','nflat']]
+                df_continuum_nflat.to_csv(nflatsave_path,header=False,index=False,sep=' ')
             if self.info and ~self.imcomb:
-                print('normalize1D: output normalized 1D spectrum= nw and ncw%d_%s.dat'%(id,self.trace.mmf))
+                print('normalize1D: output normalized 1D spectrum= nw%d_%s.dat'%(id,self.trace.mmf))
             #plot
             show_wavcal_spectrum(df_continuum_save,alpha=0.5)
             show_wavcal_spectrum(df_interp_save,alpha=0.5)
+
+class Stream1D(DatSet):
+    def __init__(self, streamid, rawdir, anadir, fitsid=None, prefix='', extension='', inst='IRD'):
+        """initialization
+        Args:
+           streamid: ID for stream
+           rawdir: directory where the raw data are
+           anadir: directory in which the processed file will put
+           fitsid: fitsid
+
+        """
+        super(Stream1D, self).__init__(rawdir, prefix=prefix, extension=extension)
+        self.streamid = streamid
+        self.rawdir = rawdir
+        self.anadir = anadir
+        self.unlock = False
+        self.info = False
+        self.inst = inst
+        if fitsid is not None:
+            print('fitsid:', fitsid)
+            self.fitsid = fitsid
+            if (fitsid[0]%2==0):
+                self.band = 'y'
+            else:
+                self.band = 'h'
+        else:
+            print('No fitsid yet.')
+        self.args = {'header':None,'delim_whitespace':True,'names':['wav','order','flux']}
+
+    @property
+    def fitsid(self):
+        return self._fitsid
+
+    @fitsid.setter
+    def fitsid(self, fitsid):
+        self._fitsid = fitsid
+        self.rawpath = self.path(string=False, check=True)
+
+    def fitsid_increment(self):
+        """Increase fits id +1."""
+        for i in range(0, len(self.fitsid)):
+            self.fitsid[i] = self.fitsid[i]+1
+        self.rawpath = self.path(string=False, check=True)
+        self.band = 'h'
+
+    def fitsid_decrement(self):
+        """Decrease fits id +1."""
+        for i in range(0, len(self.fitsid)):
+            self.fitsid[i] = self.fitsid[i]-1
+        self.rawpath = self.path(string=False, check=True)
+
+    ############################################################################################
+    def extpath(self, extension, string=False, check=True):
+        """path to file with extension.
+
+        Args:
+           extension: extension
+
+        Returns:
+           path array of fits files w/ extension
+        """
+        f = self.dir
+        e = self.extension
+        self.dir = self.anadir
+        self.extension = extension
+        path_ = self.path(string, check)
+        self.dir = f
+        self.extension = e
+        return path_
+
+    def specmedian(self):
+        """take spectrum median.
+
+        Return:
+           dataframe including median spectrum
+        """
+        specall,suffixes = [],[]
+        for i,path in enumerate(tqdm.tqdm(self.path(string=True, check=True))):
+            data = pd.read_csv(path,**self.args)
+            suffix = 'flux_%d'%(i)
+            suffixes.append(suffix)
+            data = data.rename(columns={'flux':suffix})
+            if i==0:
+                df_merge = data
+            else:
+                df_merge = pd.merge(df_merge,data,on=['wav','order'])
+        df_merge['flux_median'] = df_merge[suffixes].median(axis=1)
+        return df_merge
+
+    def remove_fringe(self):
+        """removing periodic noise (fringe) in REACH spectrum
+        """
+        from pyird.utils.remove_fringe import remove_fringe_order
+        flatpath = self.flatpath(string=True,check=True)
+        df_flat = pd.read_csv(flatpath,**self.args)
+
+        df_targetmed = self.specmedian()
+
+        orders = df_targetmed['order'].unique()
+        rmfringe_all = []
+        for order in tqdm.tqdm(orders):
+            flux_rmfringe = remove_fringe_order(df_flat,df_targetmed,order,mask=True)
+            rmfringe_all.extend(flux_rmfringe.values)
+        df_targetmed['flux_rmfringe'] = rmfringe_all
+        save_path = self.anadir/('rfnw%s_%s_%s%s.dat'%(self.streamid,self.date,self.band,self.extension))
+        df_targetmed_save = df_targetmed[['wav','order','flux_rmfringe']]
+        df_targetmed_save.to_csv(save_path,header=False,index=False,sep=' ')
+        if self.info:
+            print('removing fringe: output = rfnw%s_%s_%s%s.dat'%(self.streamid,self.date,self.band,self.extension))

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -35,6 +35,7 @@ class Stream2D(FitsSet):
         self.info = False
         self.imcomb = False
         self.inst = inst
+        self.tocsvargs = {'header':False,'index':False,'sep':' '}
         if fitsid is not None:
             print('fitsid:', fitsid)
             self.fitsid = fitsid
@@ -476,7 +477,7 @@ class Stream2D(FitsSet):
                 df_order = pd.DataFrame(data_order,index=['wav','order','flux']).T
                 wspec = pd.concat([wspec,df_order])
             wspec = wspec.fillna(0)
-            wspec.to_csv(save_path,header=False,index=False,sep=' ')
+            wspec.to_csv(save_path,**self.tocsvargs)
             return wspec
 
         if master_path==None:
@@ -551,12 +552,12 @@ class Stream2D(FitsSet):
             df_continuum, df_interp = comb_norm(wfile,flatfile)
             df_continuum_save = df_continuum[['wav','order','nflux']]
             df_interp_save = df_interp[['wav','nflux']]
-            df_continuum_save.to_csv(nwsave_path,header=False,index=False,sep=' ')
-            df_interp_save.to_csv(ncwsave_path,header=False,index=False,sep=' ')
+            df_continuum_save.to_csv(nwsave_path,**self.tocsvargs)
+            df_interp_save.to_csv(ncwsave_path,**self.tocsvargs)
             if i==0:
                 nflatsave_path = self.anadir/('nwflat_%s_%s.dat'%(self.band,self.trace.mmf))
                 df_continuum_nflat = df_continuum[['wav','order','nflat']]
-                df_continuum_nflat.to_csv(nflatsave_path,header=False,index=False,sep=' ')
+                df_continuum_nflat.to_csv(nflatsave_path,**self.tocsvargs)
             if self.info and ~self.imcomb:
                 print('normalize1D: output normalized 1D spectrum= nw%d_%s.dat'%(id,self.trace.mmf))
             #plot
@@ -580,6 +581,8 @@ class Stream1D(DatSet):
         self.unlock = False
         self.info = False
         self.inst = inst
+        self.readargs = {'header':None,'delim_whitespace':True,'names':['wav','order','flux']}
+        self.tocsvargs = {'header':False,'index':False,'sep':' '}
         if fitsid is not None:
             print('fitsid:', fitsid)
             self.fitsid = fitsid
@@ -589,7 +592,6 @@ class Stream1D(DatSet):
                 self.band = 'h'
         else:
             print('No fitsid yet.')
-        self.args = {'header':None,'delim_whitespace':True,'names':['wav','order','flux']}
 
     @property
     def fitsid(self):
@@ -640,7 +642,7 @@ class Stream1D(DatSet):
         """
         specall,suffixes = [],[]
         for i,path in enumerate(tqdm.tqdm(self.path(string=True, check=True))):
-            data = pd.read_csv(path,**self.args)
+            data = pd.read_csv(path,**self.readargs)
             suffix = 'flux_%d'%(i)
             suffixes.append(suffix)
             data = data.rename(columns={'flux':suffix})
@@ -656,7 +658,7 @@ class Stream1D(DatSet):
         """
         from pyird.utils.remove_fringe import remove_fringe_order
         flatpath = self.flatpath(string=True,check=True)
-        df_flat = pd.read_csv(flatpath,**self.args)
+        df_flat = pd.read_csv(flatpath,**self.readargs)
 
         df_targetmed = self.specmedian()
 
@@ -668,6 +670,6 @@ class Stream1D(DatSet):
         df_targetmed['flux_rmfringe'] = rmfringe_all
         save_path = self.anadir/('rfnw%s_%s_%s%s.dat'%(self.streamid,self.date,self.band,self.extension))
         df_targetmed_save = df_targetmed[['wav','order','flux_rmfringe']]
-        df_targetmed_save.to_csv(save_path,header=False,index=False,sep=' ')
+        df_targetmed_save.to_csv(save_path,**self.tocsvargs)
         if self.info:
             print('removing fringe: output = rfnw%s_%s_%s%s.dat'%(self.streamid,self.date,self.band,self.extension))

--- a/src/pyird/utils/remove_fringe.py
+++ b/src/pyird/utils/remove_fringe.py
@@ -1,0 +1,108 @@
+import pandas as pd
+import numpy as np
+from astropy.timeseries import LombScargle
+
+import argparse
+
+
+def ls_periodogram(wav,flux,search=True):
+    """Lomb-Scargle periodogram
+
+    Args:
+        wav: wavelength [nm]
+        flux: flux
+        search: if True, the output includes the frequencies
+                corresponding to the three strongest peaks
+
+    Returns:
+        results of periodogram
+    """
+    ls = LombScargle(wav,flux,normalization='psd')
+    frequency,power = ls.autopower(method='fast')
+    flux_ones = np.ones(len(wav))
+    frequency_window,power_window = LombScargle(wav,flux_ones,fit_mean=False,center_data=False,normalization='psd').autopower(method='fast')
+
+    if search==True:
+        search_min, search_max = 0.05,0.5
+        sep_hz = 0.3 ##separate >0.3Hz
+        ind = (1/search_max<frequency) & (frequency<1/search_min)
+        freq_sort = frequency[ind][np.argsort(power[ind])[::-1]]
+        if len(freq_sort)!=0:
+            f_max = freq_sort[0]
+            f_second = freq_sort[np.abs(freq_sort-freq_sort[0])>sep_hz][0]
+            ind_fsec = np.where(freq_sort==f_second)[0][0]
+            f_third = freq_sort[ind_fsec:][(np.abs(freq_sort[ind_fsec:]-f_max)>sep_hz) & (np.abs(freq_sort[ind_fsec:]-f_second)>sep_hz)][0]
+        else:
+            print('skip order ')
+            f_max, f_second, f_third = 0, 0, 0
+        return ls,frequency,power,frequency_window,power_window,[f_max,f_second,f_third]
+    else:
+        return ls,frequency,power,frequency_window,power_window
+
+def mk_model(ls,freqs,x_fit):
+    """make a sinusoidal model with given frequencies
+
+    Args:
+        ls: astropy LombScargle class
+        freqs: friquencies
+        x_fit: x array for fitting
+
+    Returns:
+        model and offset
+    """
+    offset = ls.offset()
+    y_fit = offset
+    for freq in freqs:
+        theta = ls.model_parameters(freq)
+        design_matrix = ls.design_matrix(freq,x_fit)
+        y_fit += design_matrix.dot(theta)
+    return y_fit,offset
+
+def remove_fringe_order(df_flat,df_target,order,mask=True):
+    """remove periodic noise for one order
+
+    Args:
+        df_flat: DataFrame of flat (normalized flat)
+        df_target: DataFrame of target (normalized flux)
+        order: use order
+        mask: if True, mask outliers in a flat spectrum
+
+    Returns:
+        fringe removed spectrum
+    """
+
+    ## search periodic signals in the FLAT spectrum
+    useind_flat = df_flat['order']==order
+    wav_flat=df_flat['wav'][useind_flat][216:-320]
+    flux_flat=df_flat['flux'][useind_flat][216:-320]
+
+    if mask:
+        maskind = np.abs(1-flux_flat)<0.05
+        wav_flat=wav_flat[maskind]
+        flux_flat=flux_flat[maskind]
+
+    ls,frequency,power,frequency_window,power_window,freqs = ls_periodogram(wav_flat,flux_flat)
+    if np.sum(freqs)==0:
+        print(order)
+
+    ## remove periodic signal(s) from the TARGET spectrum
+    useind_target = df_target['order']==order
+    wav_target = df_target['wav'][useind_target]
+    flux_target = df_target['flux_median'][useind_target]
+
+    ls_ori,frequency_ori,power_ori,_,_,freqs_ori = ls_periodogram(wav_target[216:-320],flux_target[216:-320])
+    freqs_ori_use = []
+    for freq in freqs_ori:
+        diff = np.abs(freqs - freq)
+        useind = diff< 100
+        if True in useind:
+            freqs_ori_use.append(freq)
+    if len(freqs_ori_use)>0:
+        flux_target_fit,offset_target = mk_model(ls_ori,freqs_ori_use,wav_target)
+        flux_rmfringe = flux_target-(flux_target_fit-offset_target)
+
+        #ls_rmfringe,frequency_rmfringe,power_rmfringe,_,_,freqs_rmfringe = ls_periodogram(wav_target,flux_rmfringe)
+        return flux_rmfringe
+    else:
+        print("No prominent frequencies...")
+        return

--- a/src/pyird/utils/remove_fringe.py
+++ b/src/pyird/utils/remove_fringe.py
@@ -99,7 +99,7 @@ def remove_fringe_order(df_flat,df_target,order,mask=True):
             freqs_ori_use.append(freq)
     if len(freqs_ori_use)>0:
         flux_target_fit,offset_target = mk_model(ls_ori,freqs_ori_use,wav_target)
-        flux_rmfringe = flux_target-(flux_target_fit-offset_target)
+        flux_rmfringe = flux_target/flux_target_fit
 
         #ls_rmfringe,frequency_rmfringe,power_rmfringe,_,_,freqs_rmfringe = ls_periodogram(wav_target,flux_rmfringe)
         return flux_rmfringe

--- a/tests/utils/test_removefringe.py
+++ b/tests/utils/test_removefringe.py
@@ -1,0 +1,39 @@
+import pytest
+import numpy as np
+import pandas as pd
+from pyird.utils.remove_fringe import remove_fringe_order,ls_periodogram
+
+def test_removefringe():
+    def multi_sin(x,freqs,amps):
+        y=1
+        for i,freq in enumerate(freqs):
+            y += amps[i]*np.sin(2*np.pi*(x*freq))
+        return y
+
+    def mk_mockdata(freqs,amps,wavlim,npix,noise=0.01):
+        wav = np.linspace(wavlim[0],wavlim[1],npix)
+        flux_clean = multi_sin(wav,freqs,amps)
+        flux = np.random.normal(flux_clean,noise)
+        return wav, flux
+
+    wavlim = [1590,1610]
+    npix = 2000
+    order = 13
+
+    freqs_flat = [13,7,5]
+    amps_flat = [0.05,0.07,0.03]
+    wav_flat, flux_flat = mk_mockdata(freqs_flat,amps_flat,wavlim,npix)
+    df_flat = pd.DataFrame(np.array([wav_flat,order*np.ones(npix),flux_flat]).T,columns=['wav','order','flux'])
+
+    freqs_target = [7000]
+    amps_target = [0.04]
+    wav_target, flux_target = mk_mockdata(freqs_target,amps_target,wavlim,npix)
+    df_target = pd.DataFrame(np.array([wav_target,order*np.ones(npix),flux_target]).T,columns=['wav','order','flux_median'])
+
+    flux_rmfringe = remove_fringe_order(df_flat,df_target,order)
+    ls_rmfringe,frequency_rmfringe,power_rmfringe,_,_,freqs_rmfringe = ls_periodogram(wav_target,flux_rmfringe)
+    diff_abs = np.abs(np.array(freqs_flat) - np.array(freqs_rmfringe))
+    assert np.sum(diff_abs)>3
+
+if __name__ == '__main__':
+    test_removefringe()


### PR DESCRIPTION
### Summary of new features

- Create a new class `Stream1D` (preliminary) (with reference to Stream2D)
- Additional output nwflat_?_m?.dat from Stream2D
- Add functions for fringe removal in REACH spectrum (output is rfnw***_*_?.dat)
- **demo: please try `REACH_stream.py`, then `REACH_stream1D.py`** You will get the fringe removed spectrum like in the bottom figure. (Once you get outputs from Stream2D, it is ok just running the latter code.)

### Overview of the concept of `irdstream`

See also #69 
- Important outputs from Stream2D: w***_m?.dat, nw***_m?.dat, wflat_?_m?.dat, nwflat_?_m?.dat (<-- new!!)
    - prefix='w': wavelength calibrated spectrum
    - prefix='nw': wavelength calibrated and normalized spectrum
- Output(s) from Stream1D: rfnw***_*_?_m?.dat (from `remove_fringe()`)
    - more functions will be added to Stream1D

#### What is done in `remove_fringe()`
- Input: wavelength calibrated and normalized flat spectrum & target spectram 
- multiple frames  can be accepted for target, in that case, they are used after the median combine
- Based on the periodic noise in flat spectrum,  the noise with those frequencies in target spectrum will be subtracted 
- Images compare the spectrum before/after and their periodogram. You can see the periodic noise in the target spectrum is reduced.


![remove_fringe_demo1](https://user-images.githubusercontent.com/66584422/223951363-fce97a70-dbb9-4e15-9790-4a9a4e64f574.png)
![remove_fringe_demo2](https://user-images.githubusercontent.com/66584422/223951411-cba0af86-9282-4b31-b7b6-8db64f212e8c.png)



