### PR TITLE
update clean pattern

### DIFF
--- a/src/pyird/gp/gputils.py
+++ b/src/pyird/gp/gputils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def calc_coarsed_array(array, Ncor):
+def calc_coarsed_array(array, Ncor, cube=False):
     """coarsed array."""
     each = (array-np.median(array))
     mask = np.abs(each) > 5.0*np.std(each)
@@ -8,7 +8,10 @@ def calc_coarsed_array(array, Ncor):
     marray[mask] = None
     stacked_array = []
     for j in range(0, Ncor):
-        stacked_array.append(marray[:, j::Ncor])
+        if cube:
+            stacked_array.append(marray[j::Ncor, j::Ncor])
+        else:
+            stacked_array.append(marray[:, j::Ncor])
     stacked_array = np.array(stacked_array)
     coarsed_array = np.nanmedian(stacked_array, axis=0)
     return coarsed_array

--- a/src/pyird/image/pattern_model.py
+++ b/src/pyird/image/pattern_model.py
@@ -1,10 +1,11 @@
 import numpy as np
+from astropy.stats import sigma_clip
 from pyird.image.channel import image_to_channel_cube, channel_cube_to_image, eopixel_split, eopixel_combine
 from pyird.plot.detector import show_profile
 
 
-def median_XY_profile(calim, rm_nct=True, Ncor=64, margin_npixel=4, sigma=0.1, xscale=32, yscale=64, show=True):
-    """a simple readout pattern model.
+def median_XY_profile_v1(calim, rm_nct=True, Ncor=64, margin_npixel=4, sigma=0.1, xscale=32, yscale=64, show=True):
+    """a simple readout pattern model. (original by H.K.)
 
     Note:
         This function assumes model = cmosub_med X + cmosub_med Y+ cmo, where cmos_med=cmo-subtracted median and cmo=channel median offset. When rm_cnt=True option corrects non-common trends of channels using a 2D GP. See #10 (https://github.com/prvjapan/pyird/issues/10).
@@ -69,5 +70,87 @@ def median_XY_profile(calim, rm_nct=True, Ncor=64, margin_npixel=4, sigma=0.1, x
                                margin_npixel] = model_channel_cube[i, :, margin_npixel:-margin_npixel]+nctrend_model
 
     model_image = channel_cube_to_image(model_channel_cube)
+
+    return model_image
+
+def cal_nct(nctrend_im,margin_npixel=4,Ncor=64, sigma=0.1, xscale=32, yscale=64, cube=False):
+    from pyird.gp.gputils import calc_coarsed_array
+    from gpkron.gp2d import GP2D, RBF
+    subarray = np.zeros_like(nctrend_im)
+    subarray = subarray[:, margin_npixel:-margin_npixel]
+
+    coarsed_array = calc_coarsed_array(nctrend_im, Ncor, cube=cube)
+    #coarsed_array[coarsed_array !=coarsed_array] = np.nanmedian(coarsed_array)
+
+    nctrend_model = GP2D(coarsed_array, RBF, sigma, (xscale, yscale), pshape=np.shape(subarray))
+    return nctrend_model
+
+def median_XY_profile(calim, rm_nct=True, margin_npixel=4):
+    """a simple readout pattern model. (revised by Y.K., May 2023)
+
+    Note:
+        This function assumes model = cmosub_med X + cmosub_med Y+ cmo, where cmos_med=cmo-subtracted median and cmo=channel median offset. When rm_cnt=True option corrects non-common trends of channels using a 2D GP. See #10 (https://github.com/prvjapan/pyird/issues/10).
+
+    Args:
+        calim: masked image for read pattern calibration
+        rm_nct: remove non-common trends of channel using a GP
+        margin_npixel: # of pixels for detector margin
+
+   Returns:
+        model pattern image
+    """
+    import warnings
+    warnings.simplefilter('ignore')
+
+    ## overall trend model (scatter light)
+    sc_model = calim.copy()
+    nctrend_model_sc = cal_nct(calim,Ncor=64,xscale=512,yscale=512,cube=True)
+    sc_model[:,margin_npixel:-margin_npixel] = nctrend_model_sc
+    model_image = sc_model
+
+    ## channel cube and e/o tensor
+    cal_channel_cube = image_to_channel_cube(calim-model_image, revert=True)
+    cal_eotensor = eopixel_split(cal_channel_cube) ## eo tensor (2 [e/o] x Nchannel x xsize x ysize)
+    nchan, xsize, ysize = np.shape(cal_channel_cube)
+
+    ## reject outliers
+    cal_eotensor_cut = cal_eotensor[:,:,:,margin_npixel:-margin_npixel]
+    mask = sigma_clip(cal_eotensor_cut,maxiters=1).mask
+    cal_eotensor_filtered = cal_eotensor_cut.copy()
+    cal_eotensor_filtered[mask] = np.nan
+
+    ## median as model
+    channel_median_offset = np.nanmedian(cal_eotensor_filtered, axis=(2, 3))
+
+    offset_subtracted = cal_eotensor_filtered - channel_median_offset[:, :, np.newaxis, np.newaxis]
+    xyprofile_offset_subtracted_model_echan = np.nanmedian(offset_subtracted[:,::2,:,:], axis=1)
+    xyprofile_offset_subtracted_model_ochan = np.nanmedian(offset_subtracted[:,1::2,:,:], axis=1)
+    xyprofile_offset_subtracted_model = np.zeros(cal_eotensor_filtered.shape)
+    xyprofile_offset_subtracted_model[::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[0,:,:]]*16).reshape(1,16,32,2040)
+    xyprofile_offset_subtracted_model[1::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[1,:,:]]*16).reshape(1,16,32,2040)
+    xyprofile_offset_subtracted_model[::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[0,:,:]]*16).reshape(1,16,32,2040)
+    xyprofile_offset_subtracted_model[1::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[1,:,:]]*16).reshape(1,16,32,2040)
+
+    image_pattern_model_eotensor = cal_eotensor
+    image_pattern_model_eotensor[:,:,:,4:-4] = xyprofile_offset_subtracted_model + channel_median_offset[:, :, np.newaxis, np.newaxis]
+
+    model_channel_cube = eopixel_combine(image_pattern_model_eotensor) ##e/o tensorのmedianを取っただけのモデル
+
+    if rm_nct:
+        Nch = np.shape(model_channel_cube)[0]
+        for i in range(0, Nch):
+            nctrend = cal_channel_cube[i, :, :]-model_channel_cube[i, :, :]
+
+            nctrend_model = cal_nct(nctrend)
+            model_channel_cube[i, :, margin_npixel:-
+                               margin_npixel] = model_channel_cube[i, :, margin_npixel:-margin_npixel]+nctrend_model
+
+    model_image += channel_cube_to_image(model_channel_cube)
+
+    ## stripe model
+    corrected_im_tmp = calim - model_image
+    stripe = np.nanmedian(corrected_im_tmp,axis=1)
+    stripe = np.array([stripe]*2048)
+    model_image += stripe
 
     return model_image

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -161,7 +161,7 @@ class Stream2D(FitsSet):
             calim[trace_mask] = np.nan
             if hotpix_mask is not None:
                 calim[hotpix_mask] = np.nan
-            model_im = median_XY_profile(calim, show=False)
+            model_im = median_XY_profile(calim)
             corrected_im = im-model_im
             hdu = pyf.PrimaryHDU(corrected_im, header)
             hdulist = pyf.HDUList([hdu])


### PR DESCRIPTION
I changed the method for the readout noise removal.
I did not change the part of the modeling of the scatter light with 2D GP, but I changed the part calculating the median profile so that it reflects pixel profiles more finely.
(I may find a better way in the future, but I'd like to merge here for now. At least this seems to work.)

#### Overview of this modification:
<img width="1000" alt="スクリーンショット 2023-04-17 20 39 50" src="https://user-images.githubusercontent.com/66584422/235438020-0451a0df-de3d-41d4-b768-5435b40e5ab6.png">


#### Validation:
From my preliminary results, the RN removal of this version can reduce the scatter in each order/channel better than the previous method.
> $\sigma_{orig}$: std of spectrum reduced by the original reduction code (i.e. Hirano-san's code + IRAF) (orange in the left bottom figure)
> $\sigma_{pyird}$: std of spectrum reduced by pyird of after fixed (green in the left bottom figure)

<img width="1000" alt="スクリーンショット 2023-05-01 19 00 23" src="https://user-images.githubusercontent.com/66584422/235438165-61182e4a-11e4-43e3-a13b-aa20005a863d.png">

<img width="400" alt="スクリーンショット 2023-05-01 19 00 04" src="https://user-images.githubusercontent.com/66584422/235438160-dea2ec5e-d21b-4036-b274-b57495c7a66e.png">