### PR TITLE
fixed continuum fitting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v2
 
       # Setup Python
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # install package	  
       - name: Install dependencies

--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -74,14 +74,14 @@ def flatten(im, trace_func, y0, xmin, xmax, coeff, inst='IRD',onepix=False,npix=
                         iys = np.max([0, tl_int[j]+k])
                         iye = np.max([0, tl_int[j]+k+1])
                     else:
-                        iys = np.min([ny, tl_int[j]+k])
-                        iye = np.min([ny, tl_int[j]+k+1])
+                        iys = np.min([ny-1, tl_int[j]+k])
+                        iye = np.min([ny-1, tl_int[j]+k+1])
                     # At the ends of the aperture partial pixels are used. (cf. IRAF apall)
-                    apsum = np.sum(rotim[ix, iys+1:iye]) + rotim[ix,iys]*(1-tl_decimal[j]) + rotim[ix,iye]*tl_decimal[j]
+                    apsum = rotim[ix,iys]*(1-tl_decimal[j]) + rotim[ix,iye]*tl_decimal[j]
                     df_onepix['ec%d'%(k)].loc[i+1,ix+1] = apsum
             else:
                 iys = np.max([0, tl_int[j]-width_str])
-                iye = np.min([ny, tl_int[j]+width_end])
+                iye = np.min([ny-1, tl_int[j]+width_end])
                 # At the ends of the aperture partial pixels are used. (cf. IRAF apall)
                 apsum = np.sum(rotim[ix, iys+1:iye]) + rotim[ix,iys]*(1-tl_decimal[j]) + rotim[ix,iye]*tl_decimal[j]
                 eachspec.append(apsum)

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -330,7 +330,7 @@ class Stream2D(FitsSet):
         os.chdir(currentdir)
         return rsd,wav,mask,pixcoord,rotim,iys_plot,iye_plot#,xmin,xmax
 
-    def apnormalize(self,rsd=None,hotpix_mask=None):
+    def apnormalize(self,rsd=None,hotpix_mask=None,ignore_orders=None):
         """normalize 2D apertures by 1D functions
 
         Returns:
@@ -351,7 +351,7 @@ class Stream2D(FitsSet):
             save_path = self.anadir/('hotpix_%s_%s.fits'%(self.band,self.trace.mmf))
             rsd = apply_hotpixel_mask(hotpix_mask, rsd, self.trace.y0, self.trace.xmin, self.trace.xmax, self.trace.coeff, save_path=save_path)
 
-        df_continuum = continuum_rsd(rsd)
+        df_continuum = continuum_rsd(rsd,ignore_orders=ignore_orders)
 
         flat_median = self.immedian('_cp')
         if not hotpix_mask is None:


### PR DESCRIPTION
I fixed the details of some functions to fit continuums.

### 1. Remove hot pixels from the blaze function
Since the last merge #74, the blaze function is created by the same process as the target. However, hot pixels that cannot remove by the hotpixel mask remained in the blaze function. So, there was the problem that noises were added when normalizing the target spectrum by it.
To create the smooth blaze function the median filter is applied for the flat image.
(see `src/pyird/utils/irdstream.py` l. 434)
![blaze_IRD](https://github.com/prvjapan/pyird/assets/66584422/914c48af-97cf-4fbe-8000-7f94f104ea44)

### 2. Iteration for the fitting process
The continuum fitting process had sometimes failed. It is because the fixed parameters are not appropriate for the variable flat images.
Fixed code iterates the process by increasing the order of fitting function until ~normalized residuals become under 5%.~ --> the std of normalized residuals become under 1.5%. The iteration stops if `order_fit` reaches `max_order_fit`.
(see `src/pyird/spec/continuum.py` l. 80~)
![blaze_REACH](https://github.com/prvjapan/pyird/assets/66584422/edce9ec8-95ee-40de-8b11-632a146c1dc1)

You can save the blaze function like the following:
```Python
flat_star.dispcor(master_path=thar.anadir,blaze=False)
flat_star.normalize1D(master_path=flat_star.anadir,skipLFC=True)
```
I also update `examples/python/REACH_stream.py`. (`IRD_stram.py` has already been updated in the last merge.)