### PR TITLE
removed nan values in the RN model and optimized aperture widths

### DIFF
--- a/src/pyird/image/mask.py
+++ b/src/pyird/image/mask.py
@@ -57,19 +57,12 @@ def trace(trace_func, y0, xmin, xmax, coeff, mask_shape=None, inst='IRD'):
     tl = trace_func(x, y0, xmin, xmax, coeff)
 #    mask = np.zeros_like(im, dtype=bool)
     mask = np.zeros(mask_shape, dtype=bool)
-    if len(y0)==21 or len(y0)==42: #h band
-        width_str = 3
-        if inst=='REACH':
-            width_end = 3
-        elif inst=='IRD':
-            width_end = 4
-    else: #if len(y0)==51 or len(y0)==102: # yj band
-        if inst=='REACH':
-            width_str = 4
-            width_end = 5
-        elif inst=='IRD':
-            width_str = 5
-            width_end = 6
+    if inst=='IRD':
+        width_str = 2
+        width_end = 4
+    elif inst=='REACH':
+        width_str = 2
+        width_end = 3
     nx, ny = mask_shape
     for i in tqdm.tqdm(range(len(y0))):
         tl_tmp = np.array(tl[i], dtype=int)

--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -25,28 +25,20 @@ def flatten(im, trace_func, y0, xmin, xmax, coeff, inst='IRD',onepix=False,npix=
     """
 
     if width is None:
-        if len(y0)==21: #h band
-            rotim = np.copy(im[::-1, ::-1])
-            width_str = 2#3
-            if inst=='REACH':
-                width_end = 3
-            elif inst=='IRD':
-                width_end = 4 ##CHECK!!
-        elif len(y0)==51: # yj band
-            rotim = np.copy(im)
-            if inst=='REACH':
-                width_str = 4
-                width_end = 5
-            elif inst=='IRD':
-                width_str = 5
-                width_end = 6
+        if inst=='IRD':
+            width_str = 2
+            width_end = 4
+        elif inst=='REACH':
+            width_str = 2
+            width_end = 3
     else:
         width_str = width[0]
         width_end = width[1]
-        if len(y0)==21: #h band
-            rotim = np.copy(im[::-1, ::-1])
-        elif len(y0)==51: # yj band
-            rotim = np.copy(im)
+
+    if len(y0)==21: #h band
+        rotim = np.copy(im[::-1, ::-1])
+    elif len(y0)==51: # yj band
+        rotim = np.copy(im)
 
     x = []
     for i in range(len(y0)):

--- a/src/pyird/image/pattern_model.py
+++ b/src/pyird/image/pattern_model.py
@@ -15,14 +15,14 @@ def cal_nct(nctrend_im,margin_npixel=4,Ncor=64, sigma=0.1, xscale=32, yscale=64,
     nctrend_model = GP2D(coarsed_array, RBF, sigma, (xscale, yscale), pshape=np.shape(subarray))
     return nctrend_model
 
-def median_XY_profile(calim, rm_nct=True, margin_npixel=4):
+def median_XY_profile(calim0, rm_nct=True, margin_npixel=4):
     """a simple readout pattern model. (revised by Y.K., May 2023)
 
     Note:
-        This function assumes model = cmosub_med X + cmosub_med Y+ cmo, where cmos_med=cmo-subtracted median and cmo=channel median offset. When rm_cnt=True option corrects non-common trends of channels using a 2D GP. See #10 (https://github.com/prvjapan/pyird/issues/10).
+        This function assumes model = cmosub_med X-Y + cmo, where cmos_med=cmo-subtracted median and cmo=channel median offset. When rm_cnt=True option corrects non-common trends of channels using a 2D GP. See #10 (https://github.com/prvjapan/pyird/issues/10).
 
     Args:
-        calim: masked image for read pattern calibration
+        calim0: masked image for read pattern calibration
         rm_nct: remove non-common trends of channel using a GP
         margin_npixel: # of pixels for detector margin
 
@@ -33,38 +33,54 @@ def median_XY_profile(calim, rm_nct=True, margin_npixel=4):
     warnings.simplefilter('ignore')
 
     ## overall trend model (scatter light)
-    sc_model = calim.copy()
-    nctrend_model_sc = cal_nct(calim,Ncor=64,xscale=512,yscale=512,cube=True)
-    sc_model[:,margin_npixel:-margin_npixel] = nctrend_model_sc
-    model_image = sc_model
+    if rm_nct:
+        sc_model = calim0.copy()
+        nctrend_model_sc = cal_nct(calim0,Ncor=64,xscale=512,yscale=512,cube=True)
+        sc_model[:,margin_npixel:-margin_npixel] = nctrend_model_sc
+        model_image = sc_model
+        calim = calim0 - model_image
+    else:
+        calim = calim0
 
     ## channel cube and e/o tensor
-    cal_channel_cube = image_to_channel_cube(calim-model_image, revert=True)
+    cal_channel_cube = image_to_channel_cube(calim, revert=True)
     cal_eotensor = eopixel_split(cal_channel_cube) ## eo tensor (2 [e/o] x Nchannel x xsize x ysize)
     nchan, xsize, ysize = np.shape(cal_channel_cube)
 
     ## reject outliers
     cal_eotensor_cut = cal_eotensor[:,:,:,margin_npixel:-margin_npixel]
     mask = sigma_clip(cal_eotensor_cut,maxiters=1).mask
-    cal_eotensor_filtered = cal_eotensor_cut.copy()
-    cal_eotensor_filtered[mask] = np.nan
+    cal_eotensor_filtered = cal_eotensor.copy()
+    cal_eotensor_filtered[:,:,:,margin_npixel:-margin_npixel][mask] = np.nan
 
-    ## median as model
+    ## cmo (channel median offset)
     channel_median_offset = np.nanmedian(cal_eotensor_filtered, axis=(2, 3))
 
+    ## cmosub_med X-Y
     offset_subtracted = cal_eotensor_filtered - channel_median_offset[:, :, np.newaxis, np.newaxis]
     xyprofile_offset_subtracted_model_echan = np.nanmedian(offset_subtracted[:,::2,:,:], axis=1)
     xyprofile_offset_subtracted_model_ochan = np.nanmedian(offset_subtracted[:,1::2,:,:], axis=1)
     xyprofile_offset_subtracted_model = np.zeros(cal_eotensor_filtered.shape)
-    xyprofile_offset_subtracted_model[::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[0,:,:]]*16).reshape(1,16,32,2040)
-    xyprofile_offset_subtracted_model[1::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[1,:,:]]*16).reshape(1,16,32,2040)
-    xyprofile_offset_subtracted_model[::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[0,:,:]]*16).reshape(1,16,32,2040)
-    xyprofile_offset_subtracted_model[1::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[1,:,:]]*16).reshape(1,16,32,2040)
+    xyprofile_offset_subtracted_model[::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[0,:,:]]*16).reshape(1,16,32,2048)
+    xyprofile_offset_subtracted_model[1::2,::2,:,:] = np.array([xyprofile_offset_subtracted_model_echan[1,:,:]]*16).reshape(1,16,32,2048)
+    xyprofile_offset_subtracted_model[::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[0,:,:]]*16).reshape(1,16,32,2048)
+    xyprofile_offset_subtracted_model[1::2,1::2,:,:] = np.array([xyprofile_offset_subtracted_model_ochan[1,:,:]]*16).reshape(1,16,32,2048)
 
-    image_pattern_model_eotensor = cal_eotensor
-    image_pattern_model_eotensor[:,:,:,4:-4] = xyprofile_offset_subtracted_model + channel_median_offset[:, :, np.newaxis, np.newaxis]
+    image_pattern_model_eotensor = xyprofile_offset_subtracted_model + channel_median_offset[:, :, np.newaxis, np.newaxis]
 
-    model_channel_cube = eopixel_combine(image_pattern_model_eotensor) ##e/o tensorのmedianを取っただけのモデル
+    ## pad nans with {cmosub_med X + cmosub_med Y}
+    xprofile_offset_subtracted = np.nanmedian(offset_subtracted, axis=3)
+    yprofile_offset_subtracted = np.nanmedian(offset_subtracted, axis=2)
+    xprofile_offset_subtracted_model = np.nanmedian(xprofile_offset_subtracted, axis=1)
+    yprofile_offset_subtracted_model = np.nanmedian(yprofile_offset_subtracted, axis=1)
+    xygrid_offset_subtracted_model =\
+        xprofile_offset_subtracted_model[:, np.newaxis, :, np.newaxis]\
+        + yprofile_offset_subtracted_model[:, np.newaxis, np.newaxis, :]\
+        + channel_median_offset[:, :, np.newaxis, np.newaxis]
+    image_pattern_model_eotensor[np.isnan(image_pattern_model_eotensor)] =\
+        xygrid_offset_subtracted_model[np.isnan(image_pattern_model_eotensor)]
+
+    model_channel_cube = eopixel_combine(image_pattern_model_eotensor)
 
     if rm_nct:
         Nch = np.shape(model_channel_cube)[0]
@@ -75,10 +91,12 @@ def median_XY_profile(calim, rm_nct=True, margin_npixel=4):
             model_channel_cube[i, :, margin_npixel:-
                                margin_npixel] = model_channel_cube[i, :, margin_npixel:-margin_npixel]+nctrend_model
 
-    model_image += channel_cube_to_image(model_channel_cube)
+        model_image += channel_cube_to_image(model_channel_cube)
+    else:
+        model_image = channel_cube_to_image(model_channel_cube)
 
     ## stripe model
-    corrected_im_tmp = calim - model_image
+    corrected_im_tmp = calim0 - model_image
     stripe = np.nanmedian(corrected_im_tmp,axis=1)
     stripe = np.array([stripe]*2048)
     model_image += stripe

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -165,13 +165,11 @@ class Stream2D(FitsSet):
                     calim[hotpix_mask] = np.nan
             elif self.band == 'y':
                 calim = np.copy(im)  # image for calibration
+                trace_mask_r = trace_mask.reshape(1, int(trace_mask.size))
+                trace_mask_r = trace_mask_r[0][::-1].reshape(im.shape[0], im.shape[1]) # rotate mask matrix 180 degree
+                calim[trace_mask_r] = np.nan
                 if hotpix_mask is not None:
-                    mask = trace_mask | hotpix_mask
-                else:
-                    mask = trace_mask
-                mask = mask.reshape(1, int(mask.size))
-                mask = mask[0][::-1].reshape(im.shape[0], im.shape[1]) # rotate mask matrix 180 degree
-                calim[mask] = np.nan
+                    calim[hotpix_mask] = np.nan
 
             model_im = median_XY_profile(calim)
             corrected_im = im - model_im

--- a/tests/io/test_iraf_trace.py
+++ b/tests/io/test_iraf_trace.py
@@ -16,7 +16,7 @@ def test_mask_from_trace_file():
     im=np.zeros((2048,2048))
     mask=trace_from_iraf_trace_file(path)
     im[mask]=1.0
-    assert int(np.sum(im))>246366
+    assert int(np.sum(im))>=246366
 
 if __name__ == '__main__':
     test_read_trace_file()

--- a/tests/utils/test_aperture.py
+++ b/tests/utils/test_aperture.py
@@ -16,7 +16,7 @@ def test_aperture():
     #import matplotlib.pyplot as plt
     #plt.imshow(ta.mask())
     #plt.show()
-    assert np.sum(ta.mask()) > 239760
+    assert np.sum(ta.mask()) >= 239760
 
 if __name__ == '__main__':
     test_aperture()


### PR DESCRIPTION
This PR fixes a bug: there sometimes appears flux=0 in a spectrum

e.g.)
<img width="500" alt="スクリーンショット 2023-07-27 10 00 58" src="https://github.com/prvjapan/pyird/assets/66584422/b6a444c6-f7f3-41ec-b2d6-4df8b6168f1c">


### Causes
- I found that flux=0 regions were related to remaining nan values in the readout noise model.
- Those nans result from failed modeling. (Especially in the part where make median model. It is partially due to too wide aperture widths.)

### Changes
- Pad nan values with the model which is combined with the medians taken along X and Y axis respectively.
- Optimized aperture widths. New widths (6 pix for IRD) are consistent with Hirano-san's reduction process.
(I confirmed that the previous aperture widths were too broad (previous: 10 pix in YJ band) and amplified the noise in YJ band. The above change may solve the large noise in YJ band #68)