### PR TITLE
fix median_XY_profile to be able to apply gap-mask

### DIFF
--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -91,7 +91,7 @@ def flatten(
                     df_onepix["ec%d" % (k)].loc[i + 1, ix + 1] = apsum
             else:
                 iys = np.max([0, tl_int[j] - width_str])
-                iye = np.min([ny - 1, tl_int[j] + width_end])
+                iye = np.min([ny - 1, tl_int[j] + width_end + 1])
                 # At the ends of the aperture partial pixels are used. (cf. IRAF apall)
                 apsum = (
                     np.sum(rotim[ix, iys + 1 : iye])

--- a/src/pyird/image/pattern_model.py
+++ b/src/pyird/image/pattern_model.py
@@ -10,7 +10,7 @@ def cal_nct(nctrend_im,margin_npixel=4,Ncor=64, sigma=0.1, xscale=32, yscale=64,
     subarray = subarray[:, margin_npixel:-margin_npixel]
 
     coarsed_array = calc_coarsed_array(nctrend_im, Ncor, cube=cube)
-    #coarsed_array[coarsed_array !=coarsed_array] = np.nanmedian(coarsed_array)
+    coarsed_array[coarsed_array !=coarsed_array] = np.nanmedian(coarsed_array)
 
     nctrend_model = GP2D(coarsed_array, RBF, sigma, (xscale, yscale), pshape=np.shape(subarray))
     return nctrend_model
@@ -97,7 +97,7 @@ def median_XY_profile(calim0, rm_nct=True, margin_npixel=4):
 
     ## stripe model
     corrected_im_tmp = calim0 - model_image
-    stripe = np.nanmedian(corrected_im_tmp,axis=1)
+    stripe = np.nanmedian(corrected_im_tmp,axis=0) ## 0
     stripe = np.array([stripe]*2048)
     model_image += stripe
 


### PR DESCRIPTION
When applying an additional mask, such as masking the columns in the direction parallel to the channel, I found that the channels including such columns fail to be NaN to all pixels in `clean_pattern()` in irdstream.py.
To avoid this issue, I changed the code to be able to deal with NaN columns, which corresponds to line 13 in `src/pyird/image/pattern_model.py`.

I also fixed other small bugs I found.