### PR TITLE
minor fix of the interpolation of nan of hotpix masking

### DIFF
--- a/src/pyird/image/hotpix.py
+++ b/src/pyird/image/hotpix.py
@@ -129,16 +129,17 @@ def apply_hotpixel_mask(hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=None)
         mask_ord = mask_ind[:,j]
         mask_edge = np.ones(len(flux[:,j]),dtype=bool)
         mask_edge[xmin[j]:xmax[j]+1] = False
-        pix_masked = pixels[:,j][~(mask_ord | mask_edge)]
-        flux_masked = flux[:,j][~(mask_ord | mask_edge)]
+        mask_nan = np.isnan(flux[:,j])
+        pix_masked = pixels[:,j][~(mask_ord | mask_edge | mask_nan)]
+        flux_masked = flux[:,j][~(mask_ord | mask_edge | mask_nan)]
 
         ### raplace bad pixels based on spline interpolation ###
-        spline_func = IUS(pix_masked, flux_masked)
+        spline_func = IUS(pix_masked, flux_masked, check_finite=True)
 
         interp_flux = spline_func(pixels[:,j])
         flux_tmp = flux[:,j].copy()
         flux_tmp[mask_ord | mask_edge] = interp_flux[mask_ord | mask_edge]
-        flux_tmp[mask_edge] = np.nan
+        flux_tmp[mask_edge | mask_nan] = np.nan
         flux_new.append(flux_tmp)
     flux_new = np.array(flux_new).T
     return flux_new

--- a/tests/image/test_hotpix.py
+++ b/tests/image/test_hotpix.py
@@ -1,8 +1,9 @@
 import pytest
-from pyird.image.hotpix import identify_hotpix,identify_hotpix_sigclip
+from pyird.image.hotpix import identify_hotpix, identify_hotpix_sigclip, apply_hotpixel_mask
 import numpy as np
 import pathlib
 import astropy.io.fits as pyf
+import pkg_resources
 
 def test_identify_hotpix():
     basedir = pathlib.Path(__file__).parent.parent.parent
@@ -18,6 +19,20 @@ def test_identify_hotpix_sigclip():
     hotpix_mask = identify_hotpix_sigclip(im)
     assert np.sum(hotpix_mask.ravel())==16556
 
+def test_apply_hotpixel_mask():
+    path=pkg_resources.resource_filename('pyird', 'data/hotpix_mask_h_202210_180s.fits')
+
+    npix = 2048
+    norder = 21
+    rsd = np.ones((npix,norder))
+    rsd[1,:] = np.nan #including nan
+    xmin = np.zeros(norder,dtype=int)
+    xmax = np.ones(norder,dtype=int) * npix
+
+    rsd_masked = apply_hotpixel_mask(None, rsd, None, xmin, xmax, None, save_path=path)
+    assert np.nansum(rsd_masked) == (npix-1)*norder
+
 if __name__ == '__main__':
     test_identify_hotpix()
     test_identify_hotpix_sigclip()
+    test_apply_hotpixel_mask()


### PR DESCRIPTION
This PR fixes a minor bug in the hotpix mask.
Because I found that the interpolation did not work when nan values existed, a process to mask nans before interpolation was added.