### PR TITLE
Bugfix for the image widget

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       # Checkout repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Setup Python
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -43,19 +43,19 @@ jobs:
       # show the results
       - name: Upload Unit Test Results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (Python 3.10)
           path: results/*.xml
 
       - name: Download Artifacts
         if: success() || failure()
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: artifacts/**/*.xml
       

--- a/src/pyird/utils/image_widget.py
+++ b/src/pyird/utils/image_widget.py
@@ -116,7 +116,7 @@ class image_1Dand2D(ttk.Frame):
         ## plot 'x' when a key is pressed
         def onkey(event):
             xi = event.xdata
-            cmap = plt.cm.get_cmap("Set1",9)
+            cmap = plt.get_cmap("Set1",9)
             color = cmap(int(xi*1e2)%9)
             rsd_ord = np.nan_to_num(rsd[:,self.order-1],0)
             if master_path is not None:

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -336,6 +336,9 @@ class Stream2D(FitsSet):
             extout_noexist = [out_path] * (not os.path.exists(out_path))
         else:
             extin_noexist, extout_noexist = self.check_existence(extin, extout)
+        if check:
+            extin_noexist = self.extpath(extin, string=False, check=False)
+            extout_noexist = self.extpath(extout, string=False, check=False)
 
         for i in tqdm.tqdm(range(len(extout_noexist))):
             if self.imcomb:
@@ -371,7 +374,7 @@ class Stream2D(FitsSet):
                 for i in range(len(y0)):
                     trace_mask[i, xmin[i] : xmax[i] + 1] = tl[i]
                 if not master_path is None:
-                    wav, _ = self.load_image(master_path)
+                    wav, _ = self.load_fits_data_header(master_path)
                 else:
                     wav = []
                 return rsd,wav,trace_mask,pixcoord,rotim,iys_plot,iye_plot
@@ -770,7 +773,7 @@ class Stream2D(FitsSet):
                     elif self.band == "y":
                         LFC_path.append(self.anadir / ("w%d_%s.dat" % (id, "m1")))
         if readout_noise_mode == 'default':
-            LFC_path = [None]
+            LFC_path = [None] * len(self.fitsid)
         datset.prefix = "w"
         wfile = datset.path(string=True,check=False)
         datset.prefix = "nw"


### PR DESCRIPTION
This PR fixes bugs related to the image widget for `examples/python/check_1Dto2D.py`.

This fix allows us to use images requiring rotate=True and/or inverse=True.