### PR TITLE
allow functions in irdstream to update attributs & bugfix of the nan mask

### DIFF
--- a/src/pyird/image/hotpix.py
+++ b/src/pyird/image/hotpix.py
@@ -138,8 +138,8 @@ def apply_hotpixel_mask(hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=None)
 
         interp_flux = spline_func(pixels[:,j])
         flux_tmp = flux[:,j].copy()
-        flux_tmp[mask_ord | mask_edge] = interp_flux[mask_ord | mask_edge]
-        flux_tmp[mask_edge | mask_nan] = np.nan
+        flux_tmp[mask_ord | mask_nan] = interp_flux[mask_ord | mask_nan]
+        flux_tmp[mask_edge] = np.nan
         flux_new.append(flux_tmp)
     flux_new = np.array(flux_new).T
     return flux_new

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -384,7 +384,20 @@ class Stream2D(FitsSet):
         self.extension = extout
         os.chdir(currentdir)
 
-    def apnormalize(self, rsd=None, hotpix_mask=None, ignore_orders=None):
+    def update_attr(self, instance, **kwargs):
+        """ Update the attributes using kwargs
+
+        Args:
+            instance: Python Class 
+            kwargs: keys and values to be updated 
+        """
+        for key, value in kwargs.items():
+            if hasattr(instance, key):
+                setattr(instance, key, value)
+            else:
+                raise AttributeError(f"ContinuumFit has no attribute named '{key}'")
+
+    def apnormalize(self, rsd=None, hotpix_mask=None, ignore_orders=None, **kwargs_continuum):
         """normalize 2D apertures by 1D functions
 
         Returns:
@@ -416,6 +429,7 @@ class Stream2D(FitsSet):
             )
 
         continuum_fit = ContinuumFit()
+        self.update_attr(continuum_fit, **kwargs_continuum)
         df_continuum = continuum_fit.continuum_rsd(rsd, ignore_orders=ignore_orders)
 
         flat_median = self.immedian("_cp")
@@ -723,7 +737,7 @@ class Stream2D(FitsSet):
             # plot
             show_wavcal_spectrum(wspec, title="Extracted spectrum: %s"%(outpath),alpha=0.5)
 
-    def normalize1D(self, flatid="blaze", master_path=None, readout_noise_mode='default', skipLFC=None):
+    def normalize1D(self, flatid="blaze", master_path=None, readout_noise_mode='default', skipLFC=None, **kwargs_normalize):
         """combine orders and normalize spectrum
 
         Args:
@@ -783,6 +797,7 @@ class Stream2D(FitsSet):
 
         for i in range(len(wfile)):
             spectrum_normalizer = SpectrumNormalizer(combfile=LFC_path[i])
+            self.update_attr(spectrum_normalizer, **kwargs_normalize)
             df_continuum, df_interp = spectrum_normalizer.combine_normalize(
                 wfile[i], flatfile, blaze=(flatid == "blaze")
             )


### PR DESCRIPTION
- I modified `irdstream.py` to set the attributes related to the continuum fitting by **kwargs.
e.g.) If you want to change the polynomial order to fit continuum, pass kwargs to `apnormalize`:
```
df_flatn = flat.apnormalize(base_order_fit=35)

# default value of base_order_fit is 25
```

- Fixed again the nan mask that has been changed #91 because the gap mask did not properly work.
   (Nan values at the gap mask were failed to set zero when wspec.fillna(0) in `irdstream.write_df_spec_wav()`)