### PR TITLE
Band option (auto fitsid_increment) when call Stream2D

### DIFF
--- a/src/pyird/spec/wavcal.py
+++ b/src/pyird/spec/wavcal.py
@@ -208,7 +208,7 @@ def identify_channel_mode(dat):
         orders = np.arange(158, 107, -1)
         print('YJ band')
     else:        
-        raise ValueError("Cannot identify H or YJ mode.")
+        raise ValueError("Cannot identify H or YJ mode. norder=", norder)
     return npix, norder, orders, channelfile
 
 def first_identification(dat, channelfile, pixel_search_area=5, kernel_size=3):

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -189,13 +189,13 @@ class Stream2D(FitsSet, StreamCommon):
             rotate (boolen): If True, the image is rotated in 90 deg (for old detector). See #80 in GitHub
             inverse (boolen): If True, the image is inversed along y axis. See #80 in GitHub
             detector_artifact (boolen): If True, fill the gaps seen in the old detector. See #80 in GitHub
-            band: band of the data, "y" or "h"
+            band: band of the data, "y" or "h", requires fitsid
             not_ignore_warning: If True and files for fitsid do not exist, raise a ValueError (default: True)
         """
         FitsSet.__init__(self, rawtag, rawdir, extension="")
         StreamCommon.__init__(self, streamid, rawdir, anadir, inst)
         self.not_ignore_warning = not_ignore_warning
-        
+
         self.imcomb = False
         self.rotate = rotate
         self.inverse = inverse
@@ -217,6 +217,8 @@ class Stream2D(FitsSet, StreamCommon):
 
     def init_band(self, band):
         """initialize band"""
+        if self.fitsid is None:
+            raise ValueError("band option requires fitsid")
         if band not in ("y", "h"):
             raise AttributeError("band must be 'y' or 'h'")
         self.band = band

--- a/tests/unittests/utils/test_stream2d.py
+++ b/tests/unittests/utils/test_stream2d.py
@@ -154,11 +154,21 @@ def test_fitsid_sets_band_at_stream2d_h_increment_error():
     stream = setup_stream2d_band("h")
     with pytest.raises(ValueError):
         stream.fitsid_increment()
+
+def test_stream2d_no_fitsid_but_band_option():
+    basedir = pathlib.Path(__file__).parent.parent.parent.parent
+    datadir = basedir / 'data/dark/'
+    anadir = basedir / 'data/dark/'
+    with pytest.raises(ValueError):
+        s2d = Stream2D('targets', datadir, anadir, band="h", not_ignore_warning=False)
     
+
+
+
 
     
         
 if __name__ == '__main__':
     test_path_1()
     test_path_2()
-    
+    test_stream2d_no_fitsid_but_band_option()

--- a/tests/unittests/utils/test_stream2d.py
+++ b/tests/unittests/utils/test_stream2d.py
@@ -104,6 +104,61 @@ def test_write_df_spec_wav(tmp_path):
     assert len(wspec) == 4
     assert list(wspec.columns) == ["wav", "order", "flux"]
 
+def test_fitsid_increment():
+    stream = setup_stream2d()
+    stream.not_ignore_warning = False 
+    val = stream.fitsid[0]
+    stream.fitsid_increment()
+    assert stream.fitsid[0] == val+1
+
+def test_fitsid_decrement():
+    stream = setup_stream2d()
+    stream.not_ignore_warning = False 
+    val = stream.fitsid[0]
+    stream.fitsid_increment()
+    stream.fitsid_decrement()
+    assert stream.fitsid[0] == val
+    
+def test_fitsid_decrement_value_error_for_no_incremented():
+    stream = setup_stream2d()
+    stream.not_ignore_warning = True
+    with pytest.raises(ValueError):
+        stream.fitsid_decrement()
+
+def test_fitsid_increment_value_error_for_double_increment():
+    stream = setup_stream2d()
+    stream.not_ignore_warning = False
+    stream.fitsid_increment()
+    with pytest.raises(ValueError):
+        stream.fitsid_increment()
+
+def setup_stream2d_band(band):
+    basedir = pathlib.Path(__file__).parent.parent.parent.parent
+    datadir = basedir / 'data/dark/'
+    anadir = basedir / 'data/dark/'
+    s2d = Stream2D('targets', datadir, anadir, fitsid = [41018], band=band, not_ignore_warning=False)
+    return s2d
+
+
+def test_fitsid_sets_band_at_stream2d_h():
+    stream = setup_stream2d_band("h")
+    assert stream.fitsid[0] == 41019
+    assert stream.band == "h"
+
+def test_fitsid_sets_band_at_stream2d_y():
+    stream = setup_stream2d_band("y")
+    assert stream.fitsid[0] == 41018
+    assert stream.band == "y"
+
+def test_fitsid_sets_band_at_stream2d_h_increment_error():
+    stream = setup_stream2d_band("h")
+    with pytest.raises(ValueError):
+        stream.fitsid_increment()
+    
+
+    
+        
 if __name__ == '__main__':
     test_path_1()
     test_path_2()
+    


### PR DESCRIPTION
This PR relates to #109 and aims to add a `band` option to prevent forgetting to call `fitsid_increment()` in the case of the H-band. When `band="h"` is specified, `fitsid_increment` is automatically executed. Additionally, if the `band` option is provided without specifying `fitsid`, a `ValueError` will be raised. 

To ensure that users do not mistakenly execute `fitsid_increment` multiple times, a `ValueError` will also be raised if it is executed more than once. The same behavior has been implemented for `fitsid_decrement`. 

For more details, please refer to the behavior of the unit tests in `test_stream2d.py`.

See also https://github.com/HajimeKawahara/anaird2501 (process.py), which works with this option.