### PR TITLE
bug fix for the calculation of uncertainties in a ncw spectrum

### DIFF
--- a/src/pyird/spec/normalize.py
+++ b/src/pyird/spec/normalize.py
@@ -281,8 +281,8 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
         flux_sum = df_head['flux'].values + flux_tail_interp
         continuum_sum = df_head['continuum'].values + continuum_tail_interp
 
-        sn_ratio_sum = sn_ratio_interp
         uncertainty_ratio_square_sum = np.sqrt(df_head['tmp_uncertainty'].values**2 + tmp_uncertainty**2)
+        sn_ratio_sum = flux_sum / uncertainty_ratio_square_sum
 
         data = np.array([df_head['wav'].values, flux_sum, continuum_sum, sn_ratio_sum, uncertainty_ratio_square_sum]).T
         df_tmp = pd.DataFrame(data, columns=df_interp.columns)

--- a/src/pyird/spec/uncertainty.py
+++ b/src/pyird/spec/uncertainty.py
@@ -127,7 +127,9 @@ class FluxUncertainty():
         for i in range(len(wav_head)):
             if (wav_head[i] == wav_tail).any():
                 print('Found an equal value!')
-                sn_ratio[i] = df_tail['sn_ratio'].values[wav_tail == wav_head[i]] 
+                ind_tmp = np.where(wav_tail == wav_head[i])
+                sn_ratio[i] = df_tail['sn_ratio'].values[ind_tmp[0][0]] 
+                tmp_uncertainty[i] = df_tail['uncertainty'].values[ind_tmp[0][0]]
             else:
                 sn_ratio[i] = np.nan
 

--- a/tests/unittests/spec/continuum/test_uncertainty.py
+++ b/tests/unittests/spec/continuum/test_uncertainty.py
@@ -48,19 +48,19 @@ def test_calc_uncertainty():
     assert df_continuum['uncertainty'][0] == expected_uncertainty
 
 def test_calc_uncertainty_overlap_region():
-    def make_mock_df(len_df):
+    def make_mock_df(len_df, snr=10):
         wavelength = np.linspace(1500, 1600, len_df)
         flux = np.ones(len(wavelength))
         continuum = np.ones(len(wavelength))
-        tmp_uncertainty = 0.01 * np.ones(len(wavelength))
-        sn_ratio = 10 * np.ones(len(wavelength))
+        tmp_uncertainty =  np.ones(len(wavelength))/snr
+        sn_ratio = snr * np.ones(len(wavelength))
         data = {'wav': wavelength, 'flux': flux, 'continuum': continuum, 'sn_ratio': sn_ratio, 'uncertainty': tmp_uncertainty}
         df = pd.DataFrame.from_dict(data)
         return df
     len_head = 101
     len_tail = 200
     df_head = make_mock_df(len_head)
-    df_tail = make_mock_df(len_tail)
+    df_tail = make_mock_df(len_tail, snr=20)
 
     flux_uncertainty = FluxUncertainty()
     sn_ratio, tmp_uncertainty = flux_uncertainty.calc_uncertainty_overlap_region(df_head, df_tail)
@@ -70,6 +70,6 @@ def test_calc_uncertainty_overlap_region():
 
 
 if __name__ == '__main__':
-    test_determine_readout_noise()
-    test_calc_uncertainty()
+    #test_determine_readout_noise()
+    #test_calc_uncertainty()
     test_calc_uncertainty_overlap_region()


### PR DESCRIPTION
This PR fixes a bug in the computation of uncertainties.
I found that the computation failed in wavelengths where they overlapped with adjacent orders.
Uncertainties in those wavelength regions were incorrectly set to zero, likely due to a missed setting of `tmp_uncertainty`.