### PR TITLE
Modifications to support IRCS data

### DIFF
--- a/src/pyird/image/aptrace.py
+++ b/src/pyird/image/aptrace.py
@@ -20,7 +20,7 @@ def cross_section(dat, nrow, nap):
     """
     onerow = dat[nrow]
     # search peaks
-    heights = np.arange(50, 0, -5) * np.median(onerow)
+    heights = np.arange(50, 0, -5) * np.abs(np.median(onerow))
     i = 0
     diffstd = 100
     peakind = []
@@ -61,8 +61,12 @@ def set_aperture(dat, cutrow, nap, ign_ord=[], plot=True):
 
     # Search peaks in the cross section at cutrow
     # cutrow is selected so that the number of peaks and nap match
-    cutrow_min = 500
-    cutrow_max = 1550
+    npix = dat.shape[0]
+    cutrow_min = int(500 * npix/2048)
+    cutrow_max = int(1550 * npix/2048)
+    if (cutrow < cutrow_min) or (cutrow_max < cutrow):
+        raise ValueError('Error: please set the value of "cutrow" between %d and %d.' % (cutrow_min, cutrow_max))
+    
     peakind_cut = []
     cutrow_lim = True
     prange = False
@@ -86,7 +90,6 @@ def set_aperture(dat, cutrow, nap, ign_ord=[], plot=True):
         )
         raise ValueError("Error: %d apertures could not be found." % (nap))
 
-        return
     print("cross-section: row ", cutrow)
     if plot == True:
         # Plot to confirm the selected aperture
@@ -251,22 +254,22 @@ def aptrace(dat, cutrow, nap, ign_ord=[], plot=True):
         warnings.warn("Looks a single fiber aperture on the detector.", UserWarning)
     else:
         warnings.warn(
-            "nap is not default value. default: nap = 42 for H / 102 for YJ.",
+            '"nap" is not default value. default: nap = 42 for H / 102 for YJ if you analyse IRD or REACH data.',
             UserWarning,
         )
 
     peakind_cut, row = set_aperture(dat, cutrow, nap, ign_ord=ign_ord, plot=plot)
 
     # Trace each peak
+    npix = dat.shape[0]
     x, y, y0 = [], [], []
     for peakind in tqdm(peakind_cut):
-        x_ord, y_ord, y0_ord = trace_pix(dat, row, peakind)
+        x_ord, y_ord, y0_ord = trace_pix(dat, row, peakind, npix=npix)
         x.append(list(x_ord))
         y.append(list(y_ord))
         y0.append(y0_ord)
     if plot == True:
-        plot_tracelines(x, y)
-
+        plot_tracelines(x, y, npix=npix)
     # Fit each aperture
     coeff = []
     xmin, xmax = [], []

--- a/src/pyird/image/mask.py
+++ b/src/pyird/image/mask.py
@@ -39,8 +39,8 @@ def trace(trace_func, y0, xmin, xmax, coeff, mask_shape=None, inst='IRD', width=
        xmax: xmax
        coeff: coefficients
        mask_shape: (optional) shape of mask, c.f. np.shape(image)
-       inst: IRD or REACH
-       width: list of aperture widths ([width_start,width_end])
+       inst: IRD or REACH or IRCS
+       width: list of aperture widths to create aperture mask ([width_start,width_end])
 
     Returns:
        mask image (same shape as im)
@@ -65,6 +65,9 @@ def trace(trace_func, y0, xmin, xmax, coeff, mask_shape=None, inst='IRD', width=
         elif inst=='REACH':
             width_str = 2
             width_end = 3
+        elif inst=='IRCS':
+            width_str = 4
+            width_end = 4
     else:
         width_str = width[0]
         width_end = width[1]

--- a/src/pyird/image/oned_extract.py
+++ b/src/pyird/image/oned_extract.py
@@ -27,10 +27,10 @@ def flatten(
         xmin: xmin
         xmax: xmax
         coeff: coefficients
-        inst: instrument (IRD or REACH)
+        inst: instrument (IRD or REACH or IRCS)
         onepix: extract the spectrum pixel by pixel in an aperture
         npix: number of pixels
-        width: list of aperture widths ([width_start,width_end])
+        width: list of aperture widths to extract spectrum ([width_start,width_end])
         force_rotate: forces rotating the detector, when the number of the apertures (nap) is not the standard value (i.e. 21 or 51)
         
     Returns:
@@ -45,6 +45,9 @@ def flatten(
         elif inst == "REACH":
             width_str = 2
             width_end = 3
+        elif inst == "IRCS":
+            width_str = 4
+            width_end = 4
     else:
         width_str = width[0]
         width_end = width[1]
@@ -120,7 +123,7 @@ def sum_weighted_apertures(im, df_flatn, y0, xmin, xmax, coeff, width, inst):
         xmin: xmin
         xmax: xmax
         coeff: coefficients
-        inst: instrument (IRD or REACH)
+        inst: instrument (IRD or REACH or IRCS)
         onepix: extract the spectrum pixel by pixel in an aperture
         npix: number of pixels
         width: list of aperture widths ([width_start,width_end])

--- a/src/pyird/image/pattern_model.py
+++ b/src/pyird/image/pattern_model.py
@@ -161,9 +161,10 @@ def median_XY_profile(calim0, rm_nct=True, margin_npixel=4):
         model_image = channel_cube_to_image(model_channel_cube)
 
     ## stripe model
+    npix = calim0.shape[0]
     corrected_im_tmp = calim0 - model_image
     stripe = np.nanmedian(corrected_im_tmp, axis=0) ## column direction
-    stripe = np.array([stripe]*2048)
+    stripe = np.array([stripe]*npix)
     model_image += stripe
 
     return model_image

--- a/src/pyird/plot/order.py
+++ b/src/pyird/plot/order.py
@@ -71,7 +71,7 @@ def plot_crosssection(pixels,flux,peakind,dat,cutrow):
     axs[0].legend()
     axs[0].set(title="Apertures are detected!",xlabel="pixels",ylabel="counts")
 
-    axs[1].imshow(dat,origin="lower",vmin=0,vmax=np.median(dat)*3)
+    axs[1].imshow(dat,origin="lower",vmin=0,vmax=np.abs(np.median(dat))*3)
     axs[1].axhline(y=cutrow, color='r', linestyle='--', label="cutrow")
     axs[1].plot(pixels[peakind], np.ones(len(peakind))*cutrow, 'x', color='tab:orange')
 

--- a/src/pyird/utils/aperture.py
+++ b/src/pyird/utils/aperture.py
@@ -9,7 +9,7 @@ __all__ = ["TraceAperture"]
 class TraceAperture(object):
     """aperture instance for trace class"""
 
-    def __init__(self, trace_function, y0, xmin, xmax, coeff, inst):
+    def __init__(self, trace_function, y0, xmin, xmax, coeff, inst, mask_shape):
         """initialization
 
         Args:
@@ -25,10 +25,16 @@ class TraceAperture(object):
         self.xmin = xmin
         self.xmax = xmax
         self.coeff = coeff
-        self.mmf = "mmf12"
         self.inst = inst
+        if inst in ["IRD", "REACH"]:
+            self.mmf = "mmf12"
+        elif inst in ["IRCS"]:
+            self.mmf = "ec" # echelle mode
+        else:
+            raise ValueError('Error: please set "inst" to either "IRD", "REACH", or "IRCS"')
         self.info = False
         self.width = None
+        self.mask_shape = mask_shape
 
     def mask(self):
         """mask image
@@ -47,6 +53,7 @@ class TraceAperture(object):
             self.coeff,
             inst=self.inst,
             width=self.width,
+            mask_shape=self.mask_shape,
         )
     
     def choose_aperture(self, fiber):

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -449,7 +449,8 @@ class Stream2D(FitsSet, StreamCommon):
             if not check:
                 write_fits_data_header(self.anadir / extout_noexist[i], header, rsd)
             else:
-                mask_shape = (2048, 2048)
+                npix = im.shape[0]
+                mask_shape = (npix, npix)#(2048, 2048)
                 trace_mask = np.zeros(mask_shape)
                 for i in range(len(y0)):
                     trace_mask[i, xmin[i] : xmax[i] + 1] = tl[i]
@@ -628,7 +629,7 @@ class Stream2D(FitsSet, StreamCommon):
             wavsol_2d = wavsol.reshape((npix, nord))
             write_fits_data_header(master_path, header, wavsol_2d)
 
-    def aptrace(self, cutrow=1000, nap=42, ign_ord=[]):
+    def aptrace(self, cutrow=1000, nap=42, ign_ord=[], width=None):
         """extract aperture of trace from a median image of current fitsset
 
         Args:
@@ -649,6 +650,8 @@ class Stream2D(FitsSet, StreamCommon):
         if band=='h':
             flatmedian = flatmedian[::-1, ::-1]
 
+        npix = flatmedian.shape[0]
+
         if self.detector_artifact:
             for i in range(0, 16):
                 flatmedian[63 + i * 128 : 63 + i * 128 + 1, :] = flatmedian[
@@ -660,7 +663,7 @@ class Stream2D(FitsSet, StreamCommon):
 
         y0, xmin, xmax, coeff = aptrace(flatmedian, cutrow, nap, ign_ord)
 
-        return TraceAperture(trace_legendre, y0, xmin, xmax, coeff, inst)
+        return TraceAperture(trace_legendre, y0, xmin, xmax, coeff, inst, mask_shape=(npix, npix))
 
     def dispcor(self, extin="_fl", prefix="w", master_path=None, blaze=True):
         """dispersion correct and resample spectra


### PR DESCRIPTION
To support the Subaru/IRCS data format (1k x 1k detector):
- `npix` (the number of pixels per row in the image) is automatically set based on the shape of the data
- The mask shape has been modified accordingly
- `inst="IRCS"` can be specified to apply the default aperture width for IRCS