### PR TITLE
fix bugs related to the aperture trace

### DIFF
--- a/src/pyird/image/aptrace.py
+++ b/src/pyird/image/aptrace.py
@@ -98,7 +98,7 @@ def set_aperture(dat, cutrow, nap, ign_ord=[], plot=True):
     return peakind_cut, cutrow
 
 
-def trace_pix(dat, cutrow, peakind, npix=2048):
+def trace_pix(dat, cutrow, peakind, npix=2048, trace_lim=[0, 1]):
     """trace apertures
 
     Args:
@@ -106,6 +106,7 @@ def trace_pix(dat, cutrow, peakind, npix=2048):
         cutrow: row number used to set aperture
         peakind: aperture (peak position) in the cross section at cutrow
         npix: number of pixels
+        trace_lim: limit of the difference between pixels in the traced aperture
 
     Returns:
         traced pixel data
@@ -136,7 +137,7 @@ def trace_pix(dat, cutrow, peakind, npix=2048):
         df_tmp = pd.DataFrame([data], columns=["row", "column"])
         traceind2d = pd.concat([traceind2d, df_tmp], ignore_index=True)
     ind = peakind
-    for nrow in range(cutrow - 1, 0, -1):
+    for nrow in range(cutrow - 1, -1, -1):
         ind_new = set_newind(dat, nrow, ind)
         if ind_new == -1:
             continue
@@ -150,7 +151,7 @@ def trace_pix(dat, cutrow, peakind, npix=2048):
     traceind2d = traceind2d.sort_values("row", ignore_index=True)
     row = traceind2d.row.values
     column = traceind2d.column.values
-    diff = np.diff(column, prepend=column[0] - 2)
+    diff = np.diff(column, prepend=column[0] - 1)
     if peakind < 40:
         useind = (
             ((0 <= diff) & (diff <= 1))
@@ -164,7 +165,7 @@ def trace_pix(dat, cutrow, peakind, npix=2048):
             & ~((column > 2020) & (row > cutrow))
         )
     else:
-        useind = ((0 <= diff) & (diff <= 1)) & (row < 2000)
+        useind = ((trace_lim[0] <= diff) & (diff <= trace_lim[1])) & (row < 2000)
     x_ord = row[useind]
     y_ord = column[useind]
 

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -198,7 +198,7 @@ class Stream2D(FitsSet, StreamCommon):
 
         self.imcomb = False
         self.rotate = rotate
-        self.inverse = inverse
+        self.inverse = inverse or (inst == "IRCS")
         self.detector_artifact = detector_artifact
 
         self.tocsvargs = {"header": False, "index": False, "sep": " "}


### PR DESCRIPTION
This PR fixes bugs related to the aperture trace:
1. The IRCS image is now inverted by default when `inst="IRCS"`, to align with PyIRD’s assumption that the image has an aperture orientation similar to that of the IRD Y/J-band detector.
2. Fixed bug of indexing in `aptrace.py`. The old script failed to trace line to the edge of the detector.

![スクリーンショット 2025-07-02 9 52 16](https://github.com/user-attachments/assets/0b2a3f7a-256c-4286-8c44-3f6e3023402b)
