### PR TITLE
Add instances to Stream1D for processing 1D spectra

### DIFF
--- a/documents/tutorials/IRD_stream_1d.ipynb
+++ b/documents/tutorials/IRD_stream_1d.ipynb
@@ -68,10 +68,6 @@
     "comb_master.imcomb = True\n",
     "comb_master.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)\n",
     "comb_master.dispcor(master_path=thar.anadir, blaze=False)\n",
-    "comb_master.normalize1D(master_path=flat_comb.anadir, \n",
-    "                   readout_noise_mode=readout_noise_mode,\n",
-    "                   outputs = [\"w\"]\n",
-    "                   )\n",
     "\"\"\""
    ]
   },

--- a/documents/tutorials/IRD_stream_1d.rst
+++ b/documents/tutorials/IRD_stream_1d.rst
@@ -48,11 +48,6 @@ LFC dataset (comb_data.tar.gz) can be downloaded from the `Zenodo repository <ht
     comb_master.imcomb = True
     comb_master.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)
     comb_master.dispcor(master_path=thar.anadir, blaze=False)
-    comb_master.normalize1D(master_path=flat_comb.anadir, 
-                       readout_noise_mode=readout_noise_mode,
-                       outputs = ["w"]
-                       )
-
 
 After running the script, confirm that a new file (e.g.,
 ``wcomb_master_h_m2.dat``) has been created in the specified analysis

--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -138,10 +138,6 @@ comb_master.clean_pattern(trace_mask=trace_mask,
 comb_master.imcomb = True
 comb_master.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)
 comb_master.dispcor(master_path=thar.anadir, blaze=False)
-comb_master.normalize1D(master_path=flat_comb.anadir, 
-                   readout_noise_mode=readout_noise_mode,
-                   outputs = ["w"]
-                   )
 
 """### hotpix (test) ###
 from pyird.image.hotpix import hotpix_fits_to_dat

--- a/examples/python/IRD_stream_1D.py
+++ b/examples/python/IRD_stream_1D.py
@@ -13,10 +13,10 @@ anadir_1d = basedir/'reduc_1d/'
 # last 5 digits of FITS file numbers: [start, end file number]
 target_id = [41510, 41511] # target image
 target_prefix = "nw"
+target_name = "G196-3B"
 #-------------------------#
 
-
-target_1d = irdstream.Stream1D("target_1d", 
+target_1d = irdstream.Stream1D(streamid=target_name, 
                                rawdir=rawdir, 
                                anadir=anadir_1d, 
                                fitsid=list(range(target_id[0], target_id[-1], 2)),
@@ -25,7 +25,21 @@ target_1d = irdstream.Stream1D("target_1d",
                                inst="IRD",
                                band=band)
 
+# wavelength recalibration with comb
 comb_master_path = rawdir / f"wcomb_master_{band}_m{mmf[-1]}.dat"
 df_recalib = target_1d.recalibrate_wavelength_with_comb(comb_master_path, fiber=mmf, n_poly=6)
 
-# df_recalib.to_csv(anadir_1d/f"pcomb_master_{band}_m{mmf[-1]}.dat", index=False, sep=' ', header=None)
+# savedir_recalib = anadir_1d/f"pcomb_master_{band}_m{mmf[-1]}.dat"
+# df_recalib.to_csv(savedir_recalib, **target_1d.tocsvargs)
+
+# airglow mask
+target_1d.mask_airglow()
+
+# combine spectra
+df_merge = target_1d.spec_combine(method="mean")
+
+savedir_merge = anadir_1d/f"{target_1d.prefix}{target_name}_{band}{target_1d.extension}.dat"
+df_merge.to_csv(savedir_merge, **target_1d.tocsvargs)
+
+# concatenate spectra (YJ + H)
+target_1d.spec_concat_yjh()

--- a/src/pyird/spec/uncertainty.py
+++ b/src/pyird/spec/uncertainty.py
@@ -126,10 +126,10 @@ class FluxUncertainty():
                 readout_noise = self.scale_normalized_mad * np.median(np.abs(comb_tmp['flux'].values - np.median(comb_tmp['flux'].values)))
             elif self.method=='std':
                 readout_noise = np.std(comb_tmp['flux'].values)
-            print('Readout Noise is :', readout_noise)
+            print('Readout Noise [ADU] is :', readout_noise)
         else:
-            readout_noise = self.default_readout_noise
-            print('Using default readout Noise :', readout_noise)
+            readout_noise = self.default_readout_noise / self.gain_y # convert to ADU
+            print('Using default readout Noise [ADU]:', readout_noise)
             print('readout noise of IRD detectors: ~12e- (10min exposure)')
 
         self.readout_noise = readout_noise

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -791,7 +791,7 @@ class Stream2D(FitsSet, StreamCommon):
         master_path=None,
         readout_noise_mode="default",
         skipLFC=None,
-        outputs=["w", "nw", "ncw"],
+        outputs=["nw", "ncw"],
         **kwargs_normalize,
     ):
         """combine orders and normalize spectrum
@@ -920,14 +920,14 @@ class Stream1D(DatSet, StreamCommon):
         self.fitsid = fitsid
 
         if prefix == "w":
-            names = ["wav", "order", "flux"]
+            self.colnames = ["wav", "order", "flux"]
         elif prefix == "nw":
-            names = ["wav", "order", "flux", "sn_ratio", "uncertainty"]
+            self.colnames = ["wav", "order", "flux", "sn_ratio", "uncertainty"]
 
         self.readargs = {
             "header": None,
             "sep": "\s+",
-            "names": names,
+            "names": self.colnames,
         }
 
         self.tocsvargs = {"header": False, "index": False, "sep": " "}
@@ -962,36 +962,106 @@ class Stream1D(DatSet, StreamCommon):
 
     ############################################################################################
 
-    def specmedian(self, method="mean"):
+    def spec_combine(self, method="mean", wav_snr_at=1500., wav_snr_width=1.):
         """take spectrum mean or median.
+        Args:
+            method: method for combining spectra, "mean" or "median"
+            wav_snr_at: wavelength at which the SNR is calculated for
+            wav_snr_width: width around 'wav_snr_at' for calculating SNR
 
         Return:
-           dataframe including median spectrum
+           dataframe including mean/median spectrum
         """
-        specall, suffixes = [], []
+        self.print_if_info_is_true(f"Combining spectra using method: {method}")
+
+        if self.prefix not in ["w", "nw"]:
+            self.dir = self.anadir
+
         for i, path in enumerate(tqdm.tqdm(self.path(string=True, check=True))):
             data = pd.read_csv(path, **self.readargs)
-            suffix = "flux_%d" % (i)
-            suffixes.append(suffix)
-            data = data.rename(
-                columns={
-                    "flux": "flux_%d" % (i),
-                    "sn_ratio": "sn_ratio_%d" % (i),
-                    "uncertainty": "uncertainty_%d" % (i),
-                }
-            )
+            data.rename(columns={"flux": f"flux_{i}", "uncertainty": f"uncertainty_{i}", "sn_ratio": f"sn_ratio_{i}"}, inplace=True)
             if i == 0:
                 df_merge = data
             else:
                 df_merge = pd.merge(df_merge, data, on=["wav", "order"])
+
         if method == "median":
-            df_merge["flux_median"] = df_merge[suffixes].median(axis=1)
+            df_merge[f"flux_{method}"] = df_merge.filter(like="flux").median(axis=1)
         elif method == "mean":
-            df_merge["flux_median"] = df_merge[suffixes].mean(axis=1)
+            df_merge[f"flux_{method}"] = df_merge.filter(like="flux").mean(axis=1)
             df_merge["flux_err"] = np.sqrt(
                 np.nansum(df_merge.filter(like="uncertainty") ** 2, axis=1)
             ) / len(df_merge.filter(like="uncertainty").columns)
+
+        df_merge = df_merge[["wav", "order", f"flux_{method}"] + (["flux_err"] if method == "mean" else [])]
+
+        # calculate SNR at specified wavelength
+        if df_merge["wav"].min() <= wav_snr_at <= df_merge["wav"].max():
+            wav_snr_min= wav_snr_at - wav_snr_width
+            wav_snr_max = wav_snr_at + wav_snr_width
+            _orders = df_merge["order"].unique()
+            mask_snr = [df_merge.loc[df_merge["order"]==ord_tmp, "wav"].between(wav_snr_min, wav_snr_max) for ord_tmp in _orders]
+            len_between = [mask_snr_tmp.sum() for mask_snr_tmp in mask_snr]
+            ind_snr = np.argmax(len_between)
+            df_merge_snr = df_merge[df_merge["order"]==_orders[ind_snr]][mask_snr[ind_snr]]
+
+            if method == "mean":
+                signal = df_merge_snr["flux_mean"].values
+                noise = df_merge_snr["flux_err"].values
+                snr_at = np.nanmean(signal / noise)
+
+            print(f"SNR around {wav_snr_at} nm (order {_orders[ind_snr]}): {snr_at:.2f}")
+        
         return df_merge
+    
+    def spec_concat_yjh(self, **kwargs):
+        """Concatenate Y/J and H band spectra into a single spectrum.
+
+        Kwargs:
+            df_y: DataFrame of Y/J band spectrum with columns ['wav', 'order', 'flux', ...]
+            df_h: DataFrame of H band spectrum with columns ['wav', 'order', 'flux', ...]
+            save_name: filename for the concatenated spectrum (e.g., 'wG196-3B_yjh.dat')
+        """
+
+        self.print_if_info_is_true("Concatenating Y/J and H band spectra...")
+
+        if self.prefix not in ["w", "nw"]:
+            self.dir = self.anadir
+
+        try:
+            df_y = kwargs["df_y"]
+            df_h = kwargs["df_h"]
+            if df_h["order"].min() < 51:
+                df_h["order"] += 51
+            
+            df_concat = pd.concat([df_y, df_h], ignore_index=True)
+
+            save_path = self.anadir / kwargs["save_name"]
+            df_concat.to_csv(save_path, **self.tocsvargs)
+
+        except:
+            for i, path in enumerate(tqdm.tqdm(self.path(string=True, check=True))):
+                if self.band == "y":
+                    fitsid_y = self.fitsid[i]
+                    path_y = path
+                    path_h = path.replace(f"{fitsid_y}", f"{self.fitsid[i] + 1}")
+                    if not os.path.exists(path_h):
+                        raise FileNotFoundError(f"not found: {path_h}")
+                elif self.band == "h":
+                    fitsid_y = self.fitsid[i] - 1
+                    path_h = path
+                    path_y = path.replace(f"{self.fitsid[i]}", f"{fitsid_y}")
+                    if not os.path.exists(path_y):
+                        raise FileNotFoundError(f"not found: {path_y}")
+
+                df_y = pd.read_csv(path_y, **self.readargs)
+                df_h = pd.read_csv(path_h, **self.readargs)
+                if df_h["order"].max() < 51:
+                    df_h["order"] += 51
+                df_concat = pd.concat([df_y, df_h], ignore_index=True)
+
+                save_path = self.anadir / f"{self.prefix}{fitsid_y}{self.extension}_yjh.dat"
+                df_concat.to_csv(save_path, **self.tocsvargs)
 
     def remove_fringe(self):
         """removing periodic noise (fringe) in REACH spectrum"""
@@ -1025,6 +1095,35 @@ class Stream1D(DatSet, StreamCommon):
                 "removing fringe: output = rfnw%s_%s_%s%s.dat"
                 % (self.streamid, self.date, self.band, self.extension)
             )
+
+    def mask_airglow(self, wav_airglow=None, plot=False):
+        """Masking airglow lines in the spectrum
+
+        Args:
+            wav_airglow: list of airglow wavelengths to be masked. If None, the default list from Oliva et al. (2015) will be used.
+            plot: if True, plot the spectrum with masked airglow lines highlighted
+        """
+        from pyird.cleaning.remove_airglow import load_oliva15, wav_around_airglow, df_mask_airglow
+
+        self.print_if_info_is_true("[STEP] Masking airglow lines...")
+
+        wav_airglow = load_oliva15() if wav_airglow is None else wav_airglow
+
+        if self.prefix not in ["w", "nw"]:
+            self.dir = self.anadir
+
+        for i, path in enumerate(tqdm.tqdm(self.path(string=True, check=True))):
+            df_obs = pd.read_csv(path, **self.readargs)
+            ind_mask = wav_around_airglow(df_obs["wav"], wav_airglow)
+            df_masked = df_mask_airglow(df_obs, ind_mask, plot=plot)
+
+            save_path = self.anadir / f"{self.prefix}{self.fitsid[i]}{self.extension}_ohmasked.dat"
+            df_masked.to_csv(save_path, **self.tocsvargs)
+            if self.info:
+                print(
+                    f"masking airglow: output = {save_path.name}"
+                )
+        self.extension += "_ohmasked"
 
     def recalibrate_wavelength_with_comb(self, comb_master_path, fiber, n_poly=6):
         from pyird.spec.wavrecal import (generate_theoretical_wavelengths_of_lfc_lines, 
@@ -1072,12 +1171,14 @@ class Stream1D(DatSet, StreamCommon):
             data['wav'] = df_recalib['wav'].values
             save_path = self.anadir / ("%s%s%s.dat" 
                                        % (prefix_new, self.fitsid[i], self.extension))
-            data_save = data[["wav", "order", "flux"]]
+            data_save = data[self.colnames]
             data_save.to_csv(save_path, **self.tocsvargs)
             if self.info:
                 print(
                     "recalibrating wavelength with comb: output = %s%s%s.dat"
                     % (prefix_new, self.fitsid[i], self.extension)
                 )
+
+        self.prefix = prefix_new
 
         return df_recalib

--- a/tests/unittests/utils/test_stream1d.py
+++ b/tests/unittests/utils/test_stream1d.py
@@ -48,15 +48,15 @@ def sample_stream1d(tmp_path):
     return stream, flux_values, uncertainty_values, wav_values
 
 
-def test_specmedian_mean_computes_average_and_error(sample_stream1d):
+def test_spec_combine_computes_average_and_error(sample_stream1d):
     stream, flux_values, uncertainty_values, _ = sample_stream1d
 
-    result = stream.specmedian(method="mean")
+    result = stream.spec_combine(method="mean")
 
     expected_flux = flux_values.mean(axis=0)
     expected_err = np.sqrt((uncertainty_values**2).sum(axis=0)) / uncertainty_values.shape[0]
 
-    assert result["flux_median"].to_numpy() == pytest.approx(expected_flux)
+    assert result["flux_mean"].to_numpy() == pytest.approx(expected_flux)
     assert result["flux_err"].to_numpy() == pytest.approx(expected_err)
 
 


### PR DESCRIPTION
This PR adds new functions for processing 1D spectra to be used in retrieval analysis.

New functions in the Stream1D class are:
- `spec_combine(self, method, wav_snr_at, wav_snr_width)`: Combines multiple spectra using either the mean or median. The SNR is calculated simultaneously.
- `spec_concat_yjh(self, **kwargs)`: Concatenates spectra to produce a single 1D spectrum covering the YJH bands.
- `mask_airglow(self, wav_airglow, plot)`: Applies a wavelength mask to remove airglow features.

The example script `examples/python/IRD_stream_1D.py` has also been updated.