### PR TITLE
Organize hotpixel handling

### DIFF
--- a/documents/tutorials/IRD_stream.ipynb
+++ b/documents/tutorials/IRD_stream.ipynb
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b1f73ecc",
    "metadata": {
     "execution": {
@@ -119,6 +119,8 @@
    "source": [
     "band = 'h' #'h' or 'y'\n",
     "mmf = 'mmf2' #'mmf1' (comb fiber) or 'mmf2' (star fiber)\n",
+    "mask_hotpix = True\n",
+    "hotpix_mode = 'nan' # 'nan' or 'interp'\n",
     "readout_noise_mode = 'default'"
    ]
   },
@@ -767,12 +769,13 @@
     "\n",
     "- In this tutorial, we demonstrate how to identify hotpixels using dark images.\n",
     "- If you prefer to load an existing hotpixel mask without using dark images, please refer to the `pyird.io.read_hotpix <https://secondearths.sakura.ne.jp/pyird/pyird/pyird.io.html#module-pyird.io.read_hotpix>`_ module.\n",
-    "- If you are interested in comparing different hotpixel mask identification methods, see issue `#121 <https://github.com/prvjapan/pyird/issues/121>`_."
+    "- If you are interested in comparing different hotpixel mask identification methods, see issue `#121 <https://github.com/prvjapan/pyird/issues/121>`_.\n",
+    "- See also :doc:`../userguide/hotpix_handling`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "7c777f65",
    "metadata": {
     "execution": {
@@ -837,7 +840,14 @@
     "                          band=band) # Multiple file is ok\n",
     "median_image = dark.immedian()\n",
     "im_subbias = bias_subtract_image(median_image)\n",
-    "hotpix_mask = identify_hotpix_sigclip(im_subbias)"
+    "hotpix_mask = identify_hotpix_sigclip(im_subbias)\n",
+    "\n",
+    "if mask_hotpix:\n",
+    "    kwargs_hotpix = {\"hotpix_mask\": hotpix_mask, \"hotpix_mode\": hotpix_mode}\n",
+    "    extin_dispcor = '_flnhp'\n",
+    "else:\n",
+    "    kwargs_hotpix = {\"hotpix_mask\": None, \"hotpix_mode\": None}\n",
+    "    extin_dispcor = '_fln'"
    ]
   },
   {
@@ -1861,7 +1871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "d2377dcf",
    "metadata": {
     "execution": {
@@ -2776,7 +2786,7 @@
     "    flat_star.imcomb = True # median combine\n",
     "\n",
     "    # Extract 1D spectrum\n",
-    "    flat_star.flatten(hotpix_mask=hotpix_mask)\n",
+    "    flat_star.flatten(**kwargs_hotpix)\n",
     "\n",
     "    # Flat spectrum normalized in each pixel within an aperture\n",
     "    df_flatn = flat_star.apnormalize()\n",
@@ -2789,7 +2799,7 @@
     "    flat_comb.imcomb = True # median combine\n",
     "\n",
     "    # Extract 1D spectrum\n",
-    "    flat_comb.flatten(hotpix_mask=hotpix_mask)\n",
+    "    flat_comb.flatten(**kwargs_hotpix)\n",
     "\n",
     "    # Flat spectrum normalized in each pixel within an aperture\n",
     "    df_flatn = flat_comb.apnormalize()"
@@ -2932,7 +2942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "fcac113a",
    "metadata": {
     "execution": {
@@ -3472,7 +3482,7 @@
     }
    ],
    "source": [
-    "target.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)"
+    "target.apext_flatfield(df_flatn, **kwargs_hotpix)"
    ]
   },
   {
@@ -3491,7 +3501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "22ee12ca",
    "metadata": {
     "execution": {
@@ -3529,7 +3539,7 @@
     }
    ],
    "source": [
-    "target.dispcor(master_path=thar.anadir, extin='_flnhp')"
+    "target.dispcor(master_path=thar.anadir, extin=extin_dispcor)"
    ]
   },
   {
@@ -4152,10 +4162,10 @@
    "source": [
     "# blaze function\n",
     "if mmf=='mmf2':\n",
-    "    flat_star.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)\n",
+    "    flat_star.apext_flatfield(df_flatn, **kwargs_hotpix)\n",
     "    flat_star.dispcor(master_path=thar.anadir)\n",
     "elif mmf=='mmf1':\n",
-    "    flat_comb.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)\n",
+    "    flat_comb.apext_flatfield(df_flatn, **kwargs_hotpix)\n",
     "    flat_comb.dispcor(master_path=thar.anadir)"
    ]
   },

--- a/documents/tutorials/IRD_stream.rst
+++ b/documents/tutorials/IRD_stream.rst
@@ -79,6 +79,8 @@ analyze. The sample data can be downloaded from the
 
     band = 'h' #'h' or 'y'
     mmf = 'mmf2' #'mmf1' (comb fiber) or 'mmf2' (star fiber)
+    mask_hotpix = True
+    hotpix_mode = 'nan' # 'nan' or 'interp'
     readout_noise_mode = 'default'
 
 .. note::
@@ -231,6 +233,7 @@ Step 1-2: Removing hotpixels
 - If you are interested in comparing different hotpixel mask
   identification methods, see issue
   `#121 <https://github.com/prvjapan/pyird/issues/121>`_.
+- See also :doc:`../userguide/hotpix_handling`
 
 .. code:: ipython3
 
@@ -247,6 +250,13 @@ Step 1-2: Removing hotpixels
     median_image = dark.immedian()
     im_subbias = bias_subtract_image(median_image)
     hotpix_mask = identify_hotpix_sigclip(im_subbias)
+
+    if mask_hotpix:
+        kwargs_hotpix = {"hotpix_mask": hotpix_mask, "hotpix_mode": hotpix_mode}
+        extin_dispcor = '_flnhp'
+    else:
+        kwargs_hotpix = {"hotpix_mask": None, "hotpix_mode": None}
+        extin_dispcor = '_fln'
 
 
 .. parsed-literal::
@@ -380,7 +390,7 @@ Step 1-4: Creating a Normalized Flat
         flat_star.imcomb = True # median combine
     
         # Extract 1D spectrum
-        flat_star.flatten(hotpix_mask=hotpix_mask)
+        flat_star.flatten(**kwargs_hotpix)
     
         # Flat spectrum normalized in each pixel within an aperture
         df_flatn = flat_star.apnormalize()
@@ -393,7 +403,7 @@ Step 1-4: Creating a Normalized Flat
         flat_comb.imcomb = True # median combine
     
         # Extract 1D spectrum
-        flat_comb.flatten(hotpix_mask=hotpix_mask)
+        flat_comb.flatten(**kwargs_hotpix)
     
         # Flat spectrum normalized in each pixel within an aperture
         df_flatn = flat_comb.apnormalize()
@@ -519,7 +529,7 @@ Step 2-2: Aperture Extraction & Flat Fielding
 
 .. code:: ipython3
 
-    target.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)
+    target.apext_flatfield(df_flatn, **kwargs_hotpix)
 
 
 .. parsed-literal::
@@ -582,7 +592,7 @@ Step 2-3: Assigning Wavelength to the Extracted Spectrum
 
 .. code:: ipython3
 
-    target.dispcor(master_path=thar.anadir, extin='_flnhp')
+    target.dispcor(master_path=thar.anadir, extin=extin_dispcor)
 
 
 .. parsed-literal::
@@ -609,10 +619,10 @@ Step 2-4: Creating the Blaze Function
 
     # blaze function
     if mmf=='mmf2':
-        flat_star.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)
+        flat_star.apext_flatfield(df_flatn, **kwargs_hotpix)
         flat_star.dispcor(master_path=thar.anadir)
     elif mmf=='mmf1':
-        flat_comb.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)
+        flat_comb.apext_flatfield(df_flatn, **kwargs_hotpix)
         flat_comb.dispcor(master_path=thar.anadir)
 
 

--- a/documents/userguide/hotpix_handling.rst
+++ b/documents/userguide/hotpix_handling.rst
@@ -1,0 +1,50 @@
+Handling Hot Pixels and Order Edges
+====================================
+
+This page explains how hot pixels and order edges are treated in PyIRD.
+
+Hot Pixels → NaN or Interpolation
+----------------------------------
+
+The hotpix_mask can be created in two ways:
+
+1. Generated from DARK frames
+2. Loaded from a prepared mask (see :doc:`./other_settings`)
+
+This mask is applied in the following functions of the Stream2D class:
+
+- ``clean_pattern()``: Applies the hot pixel mask when modeling detector patterns.
+- ``flatten()``: Replaces hot pixels with NaN or interpolated values using a spline function.
+- ``apnormalize()``: Same as flatten().
+- ``apext_flatfield()``: Same as flatten().
+
+Note that the hot pixel mask does not affect the extracted spectrum in ``clean_pattern()``, while in the other three functions it can affect the results through interpolation via ``pyird.image.hotpix.apply_hotpixel_orderedge_mask``.
+
+For the last three functions, you can set the variable ``hotpix_mode``.
+This variable controls how hot pixels are treated:
+
+- If ``hotpix_mode="nan"``, bad pixels are replaced with ``np.nan``.
+- If ``hotpix_mode="interp"``, they are replaced using spline interpolation.
+
+.. note::
+
+    ``hotpix_mode`` is available in PyIRD version > 1.2, and the default is ``"nan"``.
+    In previous versions, the code used ``hotpix_mode="interp"``.
+
+Check the Hot Pixel Masked Positions
+"""""""""""""""""""""""""""""""""""""
+If you want to check which pixels are masked by hotpix_mask, you can extract their spectra by inserting the following code into IRD_stream.py.
+
+.. code:: python
+
+    # Example
+    # Insert at the end of IRD_stream.py
+    dark.trace = trace_mmf
+    output_fl = f"hotpix_mask_fl_{band}_m{mmf[-1]}.fits"
+    dark.flatten_im(image=hotpix_mask, trace_path=None, output_path=output_fl)
+    output_w = f"whotpix_mask_{band}_m{mmf[-1]}.dat"
+    dark.dispcor_im(input_path=output_fl, master_path=thar.anadir, output_path=output_w)
+
+Order Edges → Zero
+-------------------
+Flux at order edges, where the aperture trace fails, is automatically set to zero.

--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -8,7 +8,9 @@ basedir = pathlib.Path('~/pyird/data/20210317/').expanduser()
 
 band = 'h' #'h' or 'y'
 mmf = 'mmf2' #'mmf1' (comb fiber) or 'mmf2' (star fiber)
-readout_noise_mode = "default" #'real' or 'default'
+mask_hotpix = True
+hotpix_mode = 'nan' # 'nan' or 'interp'
+readout_noise_mode = 'default' #'real' or 'default'
 
 datadir_flat = basedir/'flat/'
 datadir_dark = basedir/'dark/'
@@ -43,13 +45,19 @@ trace_mmf.choose_aperture(fiber=mmf)
 # See pyird/io/read_hotpix.py for reading fixed mask (Optional)
 ## DARK
 dark = irdstream.Stream2D('dark', 
-                          datadir_dark, 
-                          anadir, 
-                          fitsid=list(range(dark_id[0], dark_id[-1], 2)), 
-                          band=band) # Multiple file is ok
+                        datadir_dark, 
+                        anadir, 
+                        fitsid=list(range(dark_id[0], dark_id[-1], 2)), 
+                        band=band) # Multiple file is ok
 median_image = dark.immedian()
 im_subbias = bias_subtract_image(median_image)
 hotpix_mask = identify_hotpix_sigclip(im_subbias)
+if mask_hotpix:
+    kwargs_hotpix = {"hotpix_mask": hotpix_mask, "hotpix_mode": hotpix_mode}
+    extin_dispcor = '_flnhp'
+else:
+    kwargs_hotpix = {"hotpix_mask": None, "hotpix_mode": None}
+    extin_dispcor = '_fln'
 
 ## THAR (ThAr-ThAr)
 if band=='h':
@@ -80,13 +88,13 @@ if mmf=='mmf2':
     flat_star.trace = trace_mmf
     flat_star.clean_pattern(trace_mask=trace_mask, extin='', extout='_cp', hotpix_mask=hotpix_mask)
     flat_star.imcomb = True # median combine
-    flat_star.flatten(hotpix_mask=hotpix_mask)
+    flat_star.flatten(**kwargs_hotpix)
     df_flatn = flat_star.apnormalize()
 elif mmf=='mmf1':
     flat_comb.trace = trace_mmf
     flat_comb.clean_pattern(trace_mask=trace_mask, extin='', extout='_cp', hotpix_mask=hotpix_mask)
     flat_comb.imcomb = True # median combine
-    flat_comb.flatten(hotpix_mask=hotpix_mask)
+    flat_comb.flatten(**kwargs_hotpix)
     df_flatn = flat_comb.apnormalize()
 
 #--------FOR TARGET--------#
@@ -100,20 +108,20 @@ target.trace = trace_mmf
 # clean pattern
 target.clean_pattern(trace_mask=trace_mask, extin='', extout='_cp', hotpix_mask=hotpix_mask)
 # flatten
-target.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)
+target.apext_flatfield(df_flatn, **kwargs_hotpix)
 # assign reference spectra & resample
-target.dispcor(master_path=thar.anadir, extin='_flnhp')#_hp
+target.dispcor(master_path=thar.anadir, extin=extin_dispcor)
 
 if mmf=='mmf2':
     # blaze function
-    flat_star.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)
+    flat_star.apext_flatfield(df_flatn, **kwargs_hotpix)
     flat_star.dispcor(master_path=thar.anadir)
 
     # combine & normalize
     target.normalize1D(master_path=flat_star.anadir, readout_noise_mode=readout_noise_mode)
 elif mmf=='mmf1':
     # blaze function
-    flat_comb.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask, median_filter=True)
+    flat_comb.apext_flatfield(df_flatn, **kwargs_hotpix)
     flat_comb.dispcor(master_path=thar.anadir)
 
     # combine & normalize
@@ -136,7 +144,7 @@ comb_master.clean_pattern(trace_mask=trace_mask,
                      extout='_cp', 
                      hotpix_mask=hotpix_mask)
 comb_master.imcomb = True
-comb_master.apext_flatfield(df_flatn, hotpix_mask=hotpix_mask)
+comb_master.apext_flatfield(df_flatn, **kwargs_hotpix, median_filter=False)
 comb_master.dispcor(master_path=thar.anadir, blaze=False)
 
 """### hotpix (test) ###

--- a/src/pyird/image/hotpix.py
+++ b/src/pyird/image/hotpix.py
@@ -98,16 +98,24 @@ def identify_hotpix_sigclip(im,sigma=4,maxiters=5,frac=0.005):
 
     return hotpix_mask
 
-def apply_hotpixel_mask(hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=None):
-    """ correct hotpixel.
+def apply_hotpixel_orderedge_mask(
+        hotpix_mask, 
+        rsd, 
+        y0, xmin, xmax, coeff, 
+        hotpix_mode="nan", 
+        save_path=None
+        ):
+    """ mask hotpixel and/or order edge. 
 
     Args:
-        hotpix_mask: mask made from dark
+        hotpix_mask: mask made from dark. if None, only apply order edge mask.
         rsd: extracted spectrum to be masked
         y0, xmin, xmax, coeff: trace infomation
+        hotpix_mode: raplace bad pixels by np.nan if hotpix_mode="nan", while replace them based on spline interpolation if hotpix_mode="interp". 
+        save_path: path to save hotpixel mask
 
     Returns:
-        masked and interpolated spectrum
+        masked and/or interpolated spectrum
 
     """
     from scipy.interpolate import InterpolatedUnivariateSpline as IUS
@@ -115,37 +123,42 @@ def apply_hotpixel_mask(hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=None)
     from pyird.image.trace_function import trace_legendre
     from pyird.spec.rsdmat import multiorder_to_rsd
 
-    try:
-        hdu = pyf.open(save_path)[0]
-        hotpix1D = hdu.data
-    except:
-        mask = hotpix_mask.astype(int)
-        rawspec, pixcoord, _, _, _, _ = flatten(mask, trace_legendre, y0, xmin, xmax, coeff)
-        hotpix1D = multiorder_to_rsd(rawspec, pixcoord)
-        hdux = pyf.PrimaryHDU(hotpix1D)
-        hdulist = pyf.HDUList([hdux])
-        if save_path is not None:
-            hdulist.writeto(save_path, overwrite=True)
+    if hotpix_mask is not None:
+        try:
+            hdu = pyf.open(save_path)[0]
+            hotpix1D = hdu.data
+        except:
+            mask = hotpix_mask.astype(int)
+            rawspec, pixcoord, _, _, _, _ = flatten(mask, trace_legendre, y0, xmin, xmax, coeff)
+            hotpix1D = multiorder_to_rsd(rawspec, pixcoord)
+            hdux = pyf.PrimaryHDU(hotpix1D)
+            hdulist = pyf.HDUList([hdux])
+            if save_path is not None:
+                hdulist.writeto(save_path, overwrite=True)
+        mask_ind = hotpix1D>0
 
     flux = rsd
     pixels = np.array([np.arange(0,flux.shape[0],1)]*flux.shape[1]).T
-    mask_ind = hotpix1D>0
     flux_new = []
     for j in range(flux.shape[1]):
-        mask_ord = mask_ind[:,j]
         mask_edge = np.ones(len(flux[:,j]),dtype=bool)
         mask_edge[xmin[j]:xmax[j]+1] = False
         mask_nan = np.isnan(flux[:,j])
-        pix_masked = pixels[:,j][~(mask_ord | mask_edge | mask_nan)]
-        flux_masked = flux[:,j][~(mask_ord | mask_edge | mask_nan)]
-
-        ### raplace bad pixels based on spline interpolation ###
-        spline_func = IUS(pix_masked, flux_masked, check_finite=True)
-
-        interp_flux = spline_func(pixels[:,j])
         flux_tmp = flux[:,j].copy()
-        flux_tmp[mask_ord | mask_nan] = interp_flux[mask_ord | mask_nan]
-        flux_tmp[mask_edge] = np.nan
+        if hotpix_mask is not None:
+            mask_ord = mask_ind[:,j]
+            pix_masked = pixels[:,j][~(mask_ord | mask_edge | mask_nan)]
+            flux_masked = flux[:,j][~(mask_ord | mask_edge | mask_nan)]
+
+            ### raplace bad pixels based on spline interpolation ###
+            spline_func = IUS(pix_masked, flux_masked, check_finite=True)
+
+            interp_flux = spline_func(pixels[:,j])
+            if hotpix_mode=="interp":
+                flux_tmp[mask_ord | mask_nan] = interp_flux[mask_ord | mask_nan]
+            elif hotpix_mode=="nan":
+                flux_tmp[mask_ord | mask_nan] = np.nan
+        flux_tmp[mask_edge] = 0 #np.nan
         flux_new.append(flux_tmp)
     flux_new = np.array(flux_new).T
     return flux_new

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -5,7 +5,7 @@ from pyird.utils.datset import DatSet
 from pyird.image.trace_function import trace_legendre
 from pyird.image.oned_extract import flatten
 from pyird.spec.rsdmat import multiorder_to_rsd
-from pyird.image.hotpix import apply_hotpixel_mask
+from pyird.image.hotpix import apply_hotpixel_orderedge_mask
 from pyird.utils.class_handler import update_attr
 from pyird.utils.fitsutils import load_fits_data_header, write_fits_data_header
 from pyird.plot.showspec import show_wavcal_spectrum
@@ -381,7 +381,6 @@ class Stream2D(FitsSet, StreamCommon):
             data_order = [wav, order, spec_m2[:, i]]
             df_order = pd.DataFrame(data_order, index=["wav", "order", "flux"]).T
             wspec = pd.concat([wspec, df_order])
-        wspec = wspec.fillna(0)
         wspec.to_csv(save_path, **self.tocsvargs)
         return wspec
 
@@ -441,7 +440,7 @@ class Stream2D(FitsSet, StreamCommon):
         extout="_fl",
         extin=None,
         hotpix_mask=None,
-        width=None,
+        hotpix_mode="nan",
         check=False,
         master_path=None,
     ):
@@ -451,7 +450,7 @@ class Stream2D(FitsSet, StreamCommon):
             extout: output extension
             extin: input extension
             hotpix_mask: hotpix masked spectrum ('extout' to be automatically '_hp')
-            width: list of aperture widths ([width_start,width_end])
+            hotpix_mode: how to replace the values at hot pixels ("nan" or "interp")
             check: if True, return the extracted spectrum
             master_path: if this set the path to wavelength reference file with check=True, return wavelength allocated spectrum
 
@@ -490,11 +489,11 @@ class Stream2D(FitsSet, StreamCommon):
                 im, trace_legendre, y0, xmin, xmax, coeff, inst=self.inst, width=width
             )
             rsd = multiorder_to_rsd(rawspec, pixcoord)
-            if not hotpix_mask is None:
-                save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
-                rsd = apply_hotpixel_mask(
-                    hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=save_path
-                )
+
+            save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
+            rsd = apply_hotpixel_orderedge_mask(
+                hotpix_mask, rsd, y0, xmin, xmax, coeff, hotpix_mode=hotpix_mode, save_path=save_path
+            )
             if not check:
                 write_fits_data_header(self.anadir / extout_noexist[i], header, rsd)
             else:
@@ -513,8 +512,45 @@ class Stream2D(FitsSet, StreamCommon):
         self.fitsdir = self.anadir
         self.extension = extout
 
+    def flatten_im(
+        self,
+        image,
+        trace_path=None,
+        output_path=None,
+    ):
+        """
+        flatten for a single image. simple version of flatten.
+
+        Args:
+            image: input 2d array
+            trace_path: trace file to be used in flatten
+            output_path: output file name
+
+        """
+
+        self.print_if_info_is_true("[STEP] Performing flatten of input image...")
+
+        y0, xmin, xmax, coeff, mmf, width = self.extract_trace_info(trace_path)
+
+        im = self.detector_handling(image, mode="load")
+        rawspec, pixcoord, rotim, tl, iys_plot, iye_plot = flatten(
+            im, trace_legendre, y0, xmin, xmax, coeff, inst=self.inst, width=width
+        )
+        rsd = multiorder_to_rsd(rawspec, pixcoord)
+
+        if output_path is None:
+            output_path = f"flatten_im_{self.band}_{mmf}.fits"
+        write_fits_data_header(self.anadir / output_path, None, rsd)
+
+        self.print_if_info_is_true("Created " + str(output_path))
+
     def apnormalize(
-        self, rsd=None, hotpix_mask=None, ignore_orders=None, **kwargs_continuum
+        self, 
+        rsd=None, 
+        hotpix_mask=None,
+        hotpix_mode="nan", 
+        ignore_orders=None, 
+        **kwargs_continuum
     ):
         """normalize 2D apertures by 1D functions
 
@@ -531,11 +567,10 @@ class Stream2D(FitsSet, StreamCommon):
             flatfile = self.anadir / ("%s_%s_%s.fits" % (self.streamid, self.band, mmf))
             rsd, _ = load_fits_data_header(flatfile)
 
-        if not hotpix_mask is None:
-            save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
-            rsd = apply_hotpixel_mask(
-                hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=save_path
-            )
+        save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
+        rsd = apply_hotpixel_orderedge_mask(
+            hotpix_mask, rsd, y0, xmin, xmax, coeff, hotpix_mode=hotpix_mode, save_path=save_path
+        )
 
         continuum_fit = ContinuumFit()
         update_attr(continuum_fit, **kwargs_continuum)
@@ -562,7 +597,13 @@ class Stream2D(FitsSet, StreamCommon):
         return df_flatn
 
     def apext_flatfield(
-        self, df_flatn, extout="_fln", extin=None, hotpix_mask=None, width=None, median_filter=False
+        self, 
+        df_flatn, 
+        extout="_fln", 
+        extin=None, 
+        hotpix_mask=None, 
+        hotpix_mode="nan",
+        median_filter=True
     ):
         """aperture extraction and flat fielding (c.f., hdsis_ecf.cl)
 
@@ -571,7 +612,8 @@ class Stream2D(FitsSet, StreamCommon):
             extout: extension of output files
             extin: extension of input files
             hotpix_mask: hotpix masked spectrum ('extout' to be automatically '_flnhp')
-            width: list of aperture widths ([width_start,width_end])
+            hotpix_mode: how to replace the values at hot pixels ("nan" or "interp")
+            median_filter: whether to apply a median filter to the extracted spectrum 
         """
         from pyird.spec.rsdmat import rsd_order_medfilt
         from pyird.image.oned_extract import sum_weighted_apertures
@@ -608,11 +650,11 @@ class Stream2D(FitsSet, StreamCommon):
                 im, df_flatn, y0, xmin, xmax, coeff, width, self.inst
             )
             rsd = df_sum_wap.values.T.astype(float)
-            if not hotpix_mask is None:
-                save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
-                rsd = apply_hotpixel_mask(
-                    hotpix_mask, rsd, y0, xmin, xmax, coeff, save_path=save_path
-                )
+
+            save_path = self.anadir / ("hotpix_%s_%s.fits" % (self.band, mmf))
+            rsd = apply_hotpixel_orderedge_mask(
+                hotpix_mask, rsd, y0, xmin, xmax, coeff, hotpix_mode=hotpix_mode, save_path=save_path
+            )
             if self.imcomb and median_filter:
                 rsd = rsd_order_medfilt(rsd)
             # save as fits file without applying rotation/inverse
@@ -784,6 +826,47 @@ class Stream2D(FitsSet, StreamCommon):
             show_wavcal_spectrum(
                 wspec, title="Extracted spectrum: %s" % (outpath), alpha=0.5
             )
+
+    def dispcor_im(self, input_path, master_path=None, output_path=None):
+        """
+        dispcor for a single image. simple version of dispcor.
+
+        Args:
+            input_path: path to the input file
+            master_path: path to the directory containing the master ThAr file
+            output_path: path to the output file
+
+        """
+        from pyird.utils.datset import DatSet
+
+        self.print_if_info_is_true("[STEP] Performing dispcor of input image...")
+
+        if master_path == None:
+            master_path = self.anadir.joinpath("..", "thar").resolve() / (
+                "thar_%s_%s.fits" % (self.band, self.trace.mmf)
+            )
+        elif not str(master_path).endswith(".fits"):
+            master_path = master_path / (
+                "thar_%s_%s.fits" % (self.band, self.trace.mmf)
+            )
+        self.print_if_info_is_true("Allocate wavelengths based on the ThAr file: " + str(master_path))
+
+        reference, _ = load_fits_data_header(master_path)
+
+        if not os.path.exists(input_path):
+            input_path = self.anadir / input_path
+        spec_m2, _ = load_fits_data_header(input_path)
+
+        if output_path is None:
+            output_path = f"dispcor_im_{self.band}_{self.trace.mmf}.dat"
+        save_path = self.anadir / output_path
+        wspec = self.write_df_spec_wav(spec_m2, reference, save_path)
+
+        print("Created 1D spectrum: %s" % (output_path))
+        # plot
+        show_wavcal_spectrum(
+            wspec, title="Extracted spectrum: %s" % (output_path), alpha=0.5
+        )
 
     def normalize1D(
         self,

--- a/tests/unittests/image/test_hotpix.py
+++ b/tests/unittests/image/test_hotpix.py
@@ -1,9 +1,8 @@
 import pytest
-from pyird.image.hotpix import identify_hotpix, identify_hotpix_sigclip, apply_hotpixel_mask
+from pyird.image.hotpix import identify_hotpix, identify_hotpix_sigclip, apply_hotpixel_orderedge_mask
 import numpy as np
 import pathlib
 import astropy.io.fits as pyf
-import importlib
 
 def test_identify_hotpix():
     basedir = pathlib.Path(__file__).parent.parent.parent.parent
@@ -19,21 +18,65 @@ def test_identify_hotpix_sigclip():
     hotpix_mask = identify_hotpix_sigclip(im)
     assert np.sum(hotpix_mask.ravel())==16556
 
-def test_apply_hotpixel_mask():
-    path=importlib.resources.files('pyird').joinpath('data/hotpix_mask_h_202210_180s.fits')
+@pytest.mark.parametrize("hotpix_mode, expected_nan", [("nan", True), ("interp", False)])
+def test_apply_hotpixel_orderedge_mask_hotpix_handling(tmp_path, hotpix_mode, expected_nan):
+    npix = 8
+    norder = 1
+    rsd = np.arange(npix, dtype=float).reshape(npix, norder)
+    rsd[3, 0] = np.nan
+    rsd[5, 0] = 100.0
 
-    npix = 2048
-    norder = 21
-    rsd = np.ones((npix,norder))
-    rsd[1,:] = np.nan #including nan
-    xmin = np.zeros(norder,dtype=int)
-    xmax = np.ones(norder,dtype=int) * npix
+    hotpix_mask_1d = np.zeros_like(rsd)
+    hotpix_mask_1d[5, 0] = 1
+    mask_path = tmp_path / "hotpix_mask_1d.fits"
+    pyf.writeto(mask_path, hotpix_mask_1d, overwrite=True)
 
-    rsd_masked = apply_hotpixel_mask(None, rsd, None, xmin, xmax, None, save_path=path)
-    #assert np.nansum(rsd_masked) == (npix-1)*norder  ## nans remains nans
-    assert np.nansum(rsd_masked) == (npix)*norder ## when nans are interpolated
+    xmin = np.array([1])
+    xmax = np.array([6])
+
+    rsd_masked = apply_hotpixel_orderedge_mask(
+        np.ones_like(rsd),
+        rsd,
+        None,
+        xmin,
+        xmax,
+        None,
+        hotpix_mode=hotpix_mode,
+        save_path=str(mask_path)
+    )
+
+    if expected_nan:
+        assert np.isnan(rsd_masked[3, 0])
+        assert np.isnan(rsd_masked[5, 0])
+    else:
+        assert rsd_masked[3, 0] == pytest.approx(3.0)
+        assert rsd_masked[5, 0] == pytest.approx(5.0)
+
+    assert rsd_masked[0, 0] == 0
+    assert rsd_masked[7, 0] == 0
+
+
+def test_apply_hotpixel_orderedge_mask_only_edges():
+    npix = 6
+    rsd = np.column_stack((np.arange(npix, dtype=float), np.arange(npix, dtype=float) + 10))
+    rsd[2, 0] = np.nan
+
+    xmin = np.array([1, 0])
+    xmax = np.array([3, 4])
+
+    rsd_masked = apply_hotpixel_orderedge_mask(None, rsd, None, xmin, xmax, None)
+
+    assert rsd_masked[0, 0] == 0
+    assert rsd_masked[4, 0] == 0
+    assert rsd_masked[5, 0] == 0
+    assert rsd_masked[5, 1] == 0
+    assert rsd_masked[1, 0] == rsd[1, 0]
+    assert np.isnan(rsd_masked[2, 0])
+    assert rsd_masked[3, 0] == rsd[3, 0]
+    assert np.all(rsd_masked[:5, 1] == rsd[:5, 1])
 
 if __name__ == '__main__':
     test_identify_hotpix()
     test_identify_hotpix_sigclip()
-    test_apply_hotpixel_mask()
+    test_apply_hotpixel_orderedge_mask_hotpix_handling()
+    test_apply_hotpixel_orderedge_mask_only_edges()


### PR DESCRIPTION
This PR revisits the handling of the hot pixel mask.

Please refer to the new documentation (`documents/userguide/hotpix_handling.rst`), which explains the policy for hot pixel mask handling.

The function for applying the hot pixel mask now accepts a `hotpix_mode` option. 
When `hotpix_mode="nan"`, bad pixels are replaced with np.nan. When `hotpix_mode="interp"`, they are replaced using spline interpolation.
The default is currently set to "nan", but this should be considered later.