### PR TITLE
Fix minor bugs in calculation of readout noise

### DIFF
--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -146,13 +146,3 @@ comb_master.clean_pattern(trace_mask=trace_mask,
 comb_master.imcomb = True
 comb_master.apext_flatfield(df_flatn, **kwargs_hotpix, median_filter=False)
 comb_master.dispcor(master_path=thar.anadir, blaze=False)
-
-"""### hotpix (test) ###
-from pyird.image.hotpix import hotpix_fits_to_dat
-dark.trace = trace_mmf
-dark.imcomb = True
-dark.flatten(hotpix_mask=hotpix_mask)
-file = dark.anadir/('%s_%s_%s.fits'%(dark.streamid,dark.band,dark.trace.mmf))
-save_path = dark.anadir/('%s_%s_%s.dat'%(dark.streamid,dark.band,dark.trace.mmf))
-hotpix_fits_to_dat(file,save_path)
-"""

--- a/src/pyird/spec/normalize.py
+++ b/src/pyird/spec/normalize.py
@@ -201,6 +201,11 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
         for order in orders:
             df_former, df_latter = self.define_former_and_latter(df_continuum, order, max(orders))
 
+            if (order == orders[0]) and (df_former['wav'].min() > df_latter['wav'].min()):
+                df_interp = pd.concat([df_interp, df_latter[df_interp.columns]])
+                print(f"skip order {order} due to the small range of overlap region.")
+                continue
+
             if order == max(orders):
                 df_interp = self.concat_nonoverlap_region_last_order(df_former, df_interp)
                 continue

--- a/src/pyird/spec/uncertainty.py
+++ b/src/pyird/spec/uncertainty.py
@@ -123,9 +123,9 @@ class FluxUncertainty():
             comb = pd.read_csv(combfile, **read_args) 
             comb_tmp = comb[(comb['wav'] > comb_beginning) & (comb['wav'] < comb_ending)]
             if self.method=='mad':
-                readout_noise = self.scale_normalized_mad * np.median(np.abs(comb_tmp['flux'].values - np.median(comb_tmp['flux'].values)))
+                readout_noise = self.scale_normalized_mad * np.nanmedian(np.abs(comb_tmp['flux'].values - np.nanmedian(comb_tmp['flux'].values)))
             elif self.method=='std':
-                readout_noise = np.std(comb_tmp['flux'].values)
+                readout_noise = np.nanstd(comb_tmp['flux'].values)
             print('Readout Noise [ADU] is :', readout_noise)
         else:
             readout_noise = self.default_readout_noise / self.gain_y # convert to ADU

--- a/src/pyird/spec/wavrecal.py
+++ b/src/pyird/spec/wavrecal.py
@@ -109,7 +109,7 @@ def fit_comb(df_obs, lambda_th):
     # fit Gaussian to each comb line in each order
     grouped = {ord_: g.sort_values('wav') for ord_, g in df_obs.groupby('order')}
     results = []
-    for ord in orders:
+    for ord in tqdm.tqdm(orders):
         results_ord = _fit_comb_oneord(grouped, lambda_th, ord)
         results.extend(results_ord)
 


### PR DESCRIPTION
This PR fixes the following bugs:
- NaN was returned for the readout noise when `readout_noise_mode='real'` → modified the code to use np.nanmedian().
- The wavelength overlap region for the first and second orders in the H band sometimes covered an unexpectedly broad range → ignored the first order when stitching the spectrum.
- Added a progress bar to the LFC fitting process.