### PR TITLE
Apply uncertainty calculation to pre-normalized spectra ("w..._m?.dat") & explicitly output NaN values

### DIFF
--- a/documents/tutorials/IRD_stream.ipynb
+++ b/documents/tutorials/IRD_stream.ipynb
@@ -4183,7 +4183,8 @@
     "    - Data formats are: \n",
     "        - Normalized (**nw**): `$1: Wavelength [nm]`, `$2: Order`, `$3: Counts`, `$4: S/N`, `$5: Uncertainties`\n",
     "        - Order-combined (**ncw**): `$1: Wavelength [nm]`, `$2: Counts`, `$3: S/N`, `$4: Uncertainties`\n",
-    "- For the order-combined spectra: There are overlapping wavelengths at the edges of orders, so we \"normalize\" by summing up the flux in these regions to improve the signal-to-noise ratio."
+    "    - If the `outputs` option is set to `[\"w\", \"nw\", \"ncw\"]`, the pre-normalized spectrum (**w..._m?.dat**) is overwritten to include S/N and uncertainty columns, in addition to \"nw\" and \"ncw\" spectra.\n",
+    "- For the order-combined spectra: There are overlapping wavelengths at the edges of orders, so we \"normalize\" by summing up the flux in these regions to improve the signal-to-noise ratio.\n"
    ]
   },
   {

--- a/documents/tutorials/IRD_stream.rst
+++ b/documents/tutorials/IRD_stream.rst
@@ -702,6 +702,8 @@ Step 2-5: Normalizing the Spectra
     - Order-combined (**ncw**): ``$1: Wavelength [nm]``, ``$2: Counts``,
       ``$3: S/N``, ``$4: Uncertainties``
 
+  - If the ``outputs`` option is set to ``["w", "nw", "ncw"]``, the pre-normalized spectrum (**w...\_m?.dat**) is overwritten to include S/N and uncertainty columns, in addition to "nw" and "ncw" spectra.
+
 - For the order-combined spectra: There are overlapping wavelengths at
   the edges of orders, so we “normalize” by summing up the flux in these
   regions to improve the signal-to-noise ratio.

--- a/examples/python/IRD_stream.py
+++ b/examples/python/IRD_stream.py
@@ -118,14 +118,14 @@ if mmf=='mmf2':
     flat_star.dispcor(master_path=thar.anadir)
 
     # combine & normalize
-    target.normalize1D(master_path=flat_star.anadir, readout_noise_mode=readout_noise_mode)
+    target.normalize1D(master_path=flat_star.anadir, readout_noise_mode=readout_noise_mode, outputs=["w", "nw", "ncw"])
 elif mmf=='mmf1':
     # blaze function
     flat_comb.apext_flatfield(df_flatn, **kwargs_hotpix)
     flat_comb.dispcor(master_path=thar.anadir)
 
     # combine & normalize
-    target.normalize1D(master_path=flat_comb.anadir, readout_noise_mode=readout_noise_mode)
+    target.normalize1D(master_path=flat_comb.anadir, readout_noise_mode=readout_noise_mode, outputs=["w", "nw", "ncw"])
 
 
 #--------FOR WAVELENGTH RE-CALIBRATION--------#

--- a/src/pyird/spec/normalize.py
+++ b/src/pyird/spec/normalize.py
@@ -111,10 +111,10 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
             two pandas.DataFrames of 1D normalized spectrum
             - ``df_continuum``: per-order dataframe containing columns such as
               ``"wav"``, ``"order"``, ``"flux"``, ``"continuum"``, ``"nflux"``,
-              ``"sn_ratio"``, ``"tmp_uncertainty"``.
+              ``"sn_ratio"``, ``"uncertainty"``.
             - ``df_interp``: final 1D combined dataframe (columns: ``"wav"``, ``"flux"``,
-              ``"continuum"``, ``"sn_ratio"``, ``"tmp_uncertainty"``, later augmented
-              by :meth:`divide_by_continuum` with ``"nflux"`` and ``"uncertainty"``).
+              ``"continuum"``, ``"sn_ratio"``, ``"uncertainty"``, later augmented
+              by :meth:`divide_by_continuum` with ``"nflux"`` and ``"normalized_uncertainty"``).
         """
 
         read_args = {'header': None, 'sep': r'\s+', 'names':['wav','order','flux']}
@@ -138,7 +138,7 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
 
         Returns:
             Per-order dataframe including columns ``"wav"``, ``"order"``, ``"flux"``,
-            ``"continuum"``, ``"nflux"``, ``"sn_ratio"``, ``"tmp_uncertainty"``.
+            ``"continuum"``, ``"nflux"``, ``"sn_ratio"``, ``"uncertainty"``.
         """
         blaze = blaze.assign(blaze_continuum=0)
         blaze = blaze.rename(columns={'flux':'continuum'})
@@ -191,13 +191,13 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
 
         Returns:
             pandas.DataFrame of 1D normalized spectrum with columns
-            ``"wav"``, ``"flux"``, ``"continuum"``, ``"sn_ratio"``, ``"tmp_uncertainty"``,
+            ``"wav"``, ``"flux"``, ``"continuum"``, ``"sn_ratio"``, ``"uncertainty"``,
             augmented later by :meth:`divide_by_continuum`.
         """
 
         orders = df_continuum['order'].unique()
 
-        df_interp = pd.DataFrame([],columns=['wav','flux','continuum','sn_ratio','tmp_uncertainty'])
+        df_interp = pd.DataFrame([],columns=['wav','flux','continuum','sn_ratio','uncertainty'])
         for order in orders:
             df_former, df_latter = self.define_former_and_latter(df_continuum, order, max(orders))
 
@@ -331,7 +331,7 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
         flux_sum = df_head['flux'].values + flux_tail_interp
         continuum_sum = df_head['continuum'].values + continuum_tail_interp
 
-        uncertainty_ratio_square_sum = np.sqrt(df_head['tmp_uncertainty'].values**2 + tmp_uncertainty**2)
+        uncertainty_ratio_square_sum = np.sqrt(df_head['uncertainty'].values**2 + tmp_uncertainty**2)
         sn_ratio_sum = flux_sum / uncertainty_ratio_square_sum
 
         data = np.array([df_head['wav'].values, flux_sum, continuum_sum, sn_ratio_sum, uncertainty_ratio_square_sum]).T
@@ -346,17 +346,17 @@ class SpectrumNormalizer(ContinuumFit, FluxUncertainty):
         samples to avoid division by zero.
 
         Args:
-            df_interp: pandas.DataFrame that must contain ``"flux"``, ``"continuum"``, and ``"tmp_uncertainty"``.
+            df_interp: pandas.DataFrame that must contain ``"flux"``, ``"continuum"``, and ``"uncertainty"``.
 
         Returns:
             The input dataframe with added columns:
             - ``"nflux"``: normalized flux,
-            - ``"uncertainty"``: normalized uncertainty (temporary uncertainty / continuum).
+            - ``"normalized uncertainty"``: normalized uncertainty (uncertainty / continuum).
         """
         zeroind = df_interp['continuum']==0
         df_interp = df_interp.assign(nflux=np.nan,uncertainty=np.nan)
         df_interp.loc[~zeroind,'nflux'] = df_interp['flux'][~zeroind]/df_interp['continuum'][~zeroind]
-        df_interp.loc[~zeroind,'uncertainty'] = df_interp['tmp_uncertainty'][~zeroind]/df_interp['continuum'][~zeroind]
+        df_interp.loc[~zeroind,'normalized_uncertainty'] = df_interp['uncertainty'][~zeroind]/df_interp['continuum'][~zeroind]
         return df_interp
     
 if __name__ == '__main__':

--- a/src/pyird/spec/uncertainty.py
+++ b/src/pyird/spec/uncertainty.py
@@ -139,19 +139,19 @@ class FluxUncertainty():
 
         Args:
             df_continuum: Dataframe that contains at least the columns ``"wav"``, ``"flux"``,
-            and ``"continuum"``. If ``"sn_ratio"`` or ``"tmp_uncertainty"`` exist,
+            and ``"continuum"``. If ``"sn_ratio"`` or ``"uncertainty"`` exist,
             they will be overwritten.
 
         Returns:
             The temporary (pre-normalization) uncertainty is stored in the column
-            ``"tmp_uncertainty"`` as an intermediate product.
+            ``"uncertainty"`` as an intermediate product.
         """
         self.determine_gain(df_continuum)
         
         df_continuum['sn_ratio'] = (self.gain*df_continuum['flux']) \
                                     /np.sqrt(self.gain*df_continuum['flux'] + (self.gain*self.readout_noise)**2)
-        df_continuum['tmp_uncertainty'] = np.sqrt(df_continuum['flux']/self.gain + self.readout_noise**2)
-        df_continuum['uncertainty'] = df_continuum['tmp_uncertainty']/df_continuum['continuum']
+        df_continuum['uncertainty'] = np.sqrt(df_continuum['flux']/self.gain + self.readout_noise**2)
+        df_continuum['normalized_uncertainty'] = df_continuum['uncertainty']/df_continuum['continuum']
         return df_continuum
 
 

--- a/src/pyird/utils/irdstream.py
+++ b/src/pyird/utils/irdstream.py
@@ -249,7 +249,7 @@ class Stream2D(FitsSet, StreamCommon):
         self.inverse = inverse or (inst == "IRCS")
         self.detector_artifact = detector_artifact
 
-        self.tocsvargs = {"header": False, "index": False, "sep": " "}
+        self.tocsvargs = {"header": False, "index": False, "sep": " ", "na_rep": "NaN"}
 
         self.fitsid = fitsid
         self.band = None
@@ -944,13 +944,22 @@ class Stream2D(FitsSet, StreamCommon):
         for i in range(len(wfile)):
             spectrum_normalizer = SpectrumNormalizer(combfile=LFC_path[i])
             update_attr(spectrum_normalizer, **kwargs_normalize)
-            if "nw" in outputs or "ncw" in outputs:
-                df_continuum, df_interp = spectrum_normalizer.combine_normalize(
-                    wfile[i], flatfile, blaze=(flatid == "blaze")
-                )
+            df_continuum, df_interp = spectrum_normalizer.combine_normalize(
+                wfile[i], flatfile, blaze=(flatid == "blaze")
+            )
+            if "w" in outputs:
+                df_continuum_save = df_continuum[
+                    ["wav", "order", "flux", "sn_ratio", "uncertainty"]
+                ]
+                df_continuum_save.to_csv(wfile[i], **self.tocsvargs)
+                if not self.imcomb:
+                    print(
+                        "Added errors to 1D spectrum: w%d_%s.dat"
+                        % (self.fitsid[i], self.trace.mmf)
+                    )
             if "nw" in outputs:
                 df_continuum_save = df_continuum[
-                    ["wav", "order", "nflux", "sn_ratio", "uncertainty"]
+                    ["wav", "order", "nflux", "sn_ratio", "normalized_uncertainty"]
                 ]
                 df_continuum_save.to_csv(nwsave_path[i], **self.tocsvargs)
                 if not self.imcomb:
@@ -959,7 +968,7 @@ class Stream2D(FitsSet, StreamCommon):
                         % (self.fitsid[i], self.trace.mmf)
                     )
             if "ncw" in outputs:
-                df_interp_save = df_interp[["wav", "nflux", "sn_ratio", "uncertainty"]]
+                df_interp_save = df_interp[["wav", "nflux", "sn_ratio", "normalized_uncertainty"]]
                 df_interp_save.to_csv(ncwsave_path[i], **self.tocsvargs)
                 if not self.imcomb:
                     print(
@@ -987,7 +996,16 @@ class Stream1D(DatSet, StreamCommon):
     """Class for post-processing 1D spectra.
     """
     def __init__(
-        self, streamid, rawdir, anadir, fitsid=None, prefix="", extension="", inst="IRD", band=None
+        self, 
+        streamid, 
+        rawdir, 
+        anadir, 
+        fitsid=None, 
+        prefix="", 
+        extension="", 
+        inst="IRD", 
+        band=None, 
+        colnames=None
     ):
         """initialization
         Args:
@@ -1002,18 +1020,18 @@ class Stream1D(DatSet, StreamCommon):
 
         self.fitsid = fitsid
 
-        if prefix == "w":
-            self.colnames = ["wav", "order", "flux"]
-        elif prefix == "nw":
+        if colnames is None:
             self.colnames = ["wav", "order", "flux", "sn_ratio", "uncertainty"]
+        else:
+            self.colnames = colnames
 
         self.readargs = {
             "header": None,
-            "sep": "\s+",
-            "names": self.colnames,
+            "sep": r"\s+",
+            "names": self.colnames
         }
 
-        self.tocsvargs = {"header": False, "index": False, "sep": " "}
+        self.tocsvargs = {"header": False, "index": False, "sep": " ", "na_rep": "NaN",}
 
         if inst in ["IRD", "REACH"]:
             self.init_band_IRD(band=band)
@@ -1069,9 +1087,9 @@ class Stream1D(DatSet, StreamCommon):
                 df_merge = pd.merge(df_merge, data, on=["wav", "order"])
 
         if method == "median":
-            df_merge[f"flux_{method}"] = df_merge.filter(like="flux").median(axis=1)
+            df_merge[f"flux_{method}"] = np.nanmedian(df_merge.filter(like="flux"), axis=1)
         elif method == "mean":
-            df_merge[f"flux_{method}"] = df_merge.filter(like="flux").mean(axis=1)
+            df_merge[f"flux_{method}"] = np.nanmean(df_merge.filter(like="flux"), axis=1)
             df_merge["flux_err"] = np.sqrt(
                 np.nansum(df_merge.filter(like="uncertainty") ** 2, axis=1)
             ) / len(df_merge.filter(like="uncertainty").columns)


### PR DESCRIPTION
## Important changes for users
- NaN values are now explicitly written as "NaN" in output files.
  - For pandas.to_csv(), previous arguments were `{"header": False, "index": False, "sep": " "}`; `"na_rep": "NaN"` has now been added.
  - Users can modify these args via `Stream2D().tocsvargs` (see `pyird.utils.irdstream`)

### Additional options introduced in this PR
- The `outputs` option in `Stream2D().normalize1D` allows control over output behavior.
  - The default is `outputs=["nw", "ncw"]`, which behaves the same as before.
  - If `"w"` is included in `outputs`, the pre-normalized spectrum (w..._m?.dat) is overwritten to include S/N and uncertainty columns.